### PR TITLE
[docs_2] Add EditorConfig instructions 

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -8,6 +8,7 @@ charset = utf-8
 end_of_line = lf
 insert_final_newline = true
 trim_trailing_whitespace = true
+spelling_language = en_US
 
 # 4 spaces by default
 indent_style = space
@@ -43,10 +44,21 @@ indent_size = 2
 # -----------------------------
 [*.java]
 indent_size = 4
+max_line_length = 120
 
 # -----------------------------
 # Shell scripts
 # -----------------------------
 [*.sh]
-indent_style = space
+indent_size = 2
+
+# -----------------------------
+# Database files (SQL)
+# -----------------------------
+[*.sql]
+
+# -----------------------------
+# Hardware interaction code (.ino)
+# -----------------------------
+[*.ino]
 indent_size = 2

--- a/.editorconfig
+++ b/.editorconfig
@@ -22,43 +22,16 @@ trim_trailing_whitespace = false
 max_line_length = 120
 
 # -----------------------------
-# YAML / JSON
-# -----------------------------
-[*.yml]
-indent_size = 2
-
-[*.yaml]
-indent_size = 2
-
-[*.json]
-indent_size = 2
-
-# -----------------------------
 # Frontend (TypeScript / HTML / CSS)
+# YAML / JSON
+# Shell scripts
+# Hardware interaction code (.ino)
 # -----------------------------
-[*.{ts,tsx,js,jsx,html,css,scss}]
+[*.{ts,tsx,js,jsx,html,css,scss,yml,yaml,json,sh,ino}]
 indent_size = 2
 
 # -----------------------------
 # Java
 # -----------------------------
 [*.java]
-indent_size = 4
 max_line_length = 120
-
-# -----------------------------
-# Shell scripts
-# -----------------------------
-[*.sh]
-indent_size = 2
-
-# -----------------------------
-# Database files (SQL)
-# -----------------------------
-[*.sql]
-
-# -----------------------------
-# Hardware interaction code (.ino)
-# -----------------------------
-[*.ino]
-indent_size = 2

--- a/docs/developer-guide/ide-setup.md
+++ b/docs/developer-guide/ide-setup.md
@@ -17,8 +17,13 @@ This repo includes a root `.editorconfig`. It defines:
 - Frontend: VS Code (recommended), WebStorm
 
 ### Make EditorConfig active
-- VS Code: built-in (if not, install EditorConfig extension)
-- IntelliJ: built-in
+- VS Code:
+    - Install EditorConfig extension (editorconfig.editorconfig)
+    - Set as default formatter ( e.g. by setting ``` "editor.defaultFormatter": "EditorConfig.EditorConfig" ``` in settings.json)
+- IntelliJ:
+    - EditorConfig extension should come bundled, install if not
+    - Make sure Settings -> Editor -> Code Style -> Enable EditorConfig support is checked
+    - **Note:** comment language recognition from .editorconfig is not supported. To ensure consistency, make sure Settings -> Editor -> Natural Languages is set to English (US)
 - NetBeans: ensure EditorConfig support is enabled (plugin may be required depending on version)
 
 ## Java formatting


### PR DESCRIPTION
## Linked Issue
Closes #2

## What changed
- EditorConfig sets comments spelling convention (en-US)
- Added instructions for enabling EditorConfig support in VS Code and IntelliJ Idea

## Why
- Consistency

## DB changes
- [x] None
- [ ] Migration included (describe)

## API changes
- [x] None
- [ ] OpenAPI updated
- [ ] Error catalog updated (`docs/developer-guide/error-catalog.md`)

## Tests
- [ ] Added/updated backend tests
- [ ] Added/updated frontend tests
- [ ] Added/updated E2E tests
- Notes:

## Security / data minimization
- [ ] TV receives no answers
- [x] No secrets logged

## Screenshots / video (UI changes)
(attach)
