### PR TITLE
[devops_64] Strengthen Controller Test Coverage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 
+
 # Changelog
 
 All notable changes to this project will be documented in this file.
@@ -16,7 +17,7 @@ a SemVer-like versioning scheme will be used.
 - Build and packaging documentation for cross-platform desktop distribution (Linux, Windows, macOS).
 - Root-level README files across key directories to clarify repository structure and responsibilities.
 
-#### Desktop Packaging Architecture
+### Desktop Packaging Architecture
 - Cross‑platform desktop packaging architecture enabling fully self‑contained distribution.
 - jpackage-based builds bundling a custom Java runtime via jlink (no system Java required).
 - Platform‑specific release scripts for:
@@ -31,16 +32,50 @@ a SemVer-like versioning scheme will be used.
 - Automatic browser launch on application startup for improved desktop UX.
 - Graceful shutdown strategy via Spring Boot Actuator integration.
 
-#### Build & Release Infrastructure
-- Platform‑aware Maven profile system supporting:
-  - `production`
-  - `embeddb`
+### Build / Release
+- Documented production runtime profiles (`production`, `embeddb`) and their behavior.
+- Documented embedded vs external PostgreSQL operating modes.
+- Implemented a platform-aware Maven profile system supporting:
+  - production runtime configuration
+  - embedded database mode
   - platform selection (`linux`, `windows`, `macos`)
-- Angular frontend build integrated into Maven lifecycle using `frontend-maven-plugin`.
-- Static frontend assets embedded into Spring Boot jar during production builds.
-- Packaging scripts standardized across platforms for reproducible builds.
-- Release artifact structure defined for consistent distribution outputs.
-- Runtime configuration arguments injected via packaging scripts instead of hardcoding profiles in the jar.
+- Integrated Angular frontend builds into the Maven lifecycle using `frontend-maven-plugin`.
+- Embedded static frontend assets into the Spring Boot jar during production builds.
+- Introduced cross-platform packaging scripts for generating installers and portable distributions.
+- Formalized the release artifact structure for consistent distribution outputs across platforms.
+- Ensured platform-specific embedded PostgreSQL binaries are included only where required.
+- Injected runtime configuration arguments through packaging scripts rather than hardcoding profiles in the application jar.
+- Documented platform-specific build prerequisites, including Windows toolchain requirements (e.g., WiX).
+- Improved reproducibility of release builds through standardized packaging workflows.
+
+### DevOps / Infrastructure
+- Documented docker-compose usage for development environments.
+- Clarified container vs local development workflows.
+- Added guidance for serial hardware integration in local and packaged environments.
+- Added release documentation describing how to produce distributable artifacts for all supported platforms.
+- Prepared groundwork for future CI pipelines for automated multi-platform release builds.
+
+### Testing
+
+- Expanded the backend automated test suite with stronger coverage across service, controller, and documentation‑consistency layers.
+- Service-layer unit tests remain the primary focus of the test suite and protect the core game rules implemented in:
+  - `GameServiceImpl`
+  - `InterruptServiceImpl`
+  - `ScheduleServiceImpl`
+  - `CategoryServiceImpl`
+  - `TeamServiceImpl`
+  - `SongServiceImpl`
+- Service tests validate rule-heavy logic including stage transitions, interrupt handling and resolution, schedule progression, category selection, state reconstruction, and WebSocket broadcast side effects.
+- Added structured controller-level tests to verify the HTTP contract of REST endpoints. These tests validate:
+  - happy path responses
+  - `DerivedException` responses
+  - unexpected runtime error responses
+  - HTTP status codes, response content, and response media types
+  - rejection of malformed requests before service invocation
+- Standardized controller test organization (one test file per controller with nested suites) and removed overlapping or redundant tests.
+- Introduced consistency checks ensuring that documentation and API definitions remain aligned with the implementation, including verification of Swagger/OpenAPI documentation and error-handling conventions.
+- Added and maintained a structured test catalog (`test-catalog.md` / `test-catalog.csv`) to document backend test coverage and prevent redundant tests.
+- Improved overall test readability and maintainability through clearer naming conventions, stronger assertions, and consistent Mockito static imports.
 
 ### Changed
 - Consolidated and removed outdated documentation to align with current implementation.
@@ -49,22 +84,6 @@ a SemVer-like versioning scheme will be used.
 - Updated logging documentation to reflect SLF4J + rolling log configuration.
 - Standardized documentation navigation via `docs/index.md` as the authoritative entry point.
 - Improved project structure documentation to clarify boundaries between backend, frontend, hardware, and packaging scripts.
-
-### Build / Release
-- Documented production profiles (`production`, `embeddb`) and runtime behavior.
-- Documented embedded vs external PostgreSQL modes.
-- Formalized release packaging structure and artifact layout.
-- Clarified platform-specific build prerequisites (especially Windows toolchain requirements such as WiX).
-- Introduced cross-platform packaging scripts to generate installers and portable builds.
-- Ensured platform-specific embedded PostgreSQL binaries are included only where needed.
-- Improved reproducibility of release builds by standardizing packaging workflows.
-
-### DevOps / Infrastructure
-- Documented docker-compose usage for development environments.
-- Clarified container vs local development workflows.
-- Added guidance for serial hardware integration in local and packaged environments.
-- Added release documentation describing how to produce distributable artifacts for all supported platforms.
-- Prepared groundwork for future CI pipelines for automated multi-platform release builds.
 
 ## 0.1.0 – Initial MVP
 

--- a/apps/backend/pom.xml
+++ b/apps/backend/pom.xml
@@ -291,10 +291,6 @@
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>
-            <artifactId>commons-lang3</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.commons</groupId>
             <artifactId>commons-csv</artifactId>
             <version>1.14.1</version>
             <scope>test</scope>

--- a/apps/backend/src/main/java/com/cevapinxile/cestereg/api/assets/controller/AudioAssetController.java
+++ b/apps/backend/src/main/java/com/cevapinxile/cestereg/api/assets/controller/AudioAssetController.java
@@ -4,8 +4,8 @@
  */
 package com.cevapinxile.cestereg.api.assets.controller;
 
-import com.cevapinxile.cestereg.common.exception.DerivedException;
-import com.cevapinxile.cestereg.common.exception.InternalServerErrorException;
+import static com.cevapinxile.cestereg.api.support.ApiErrorResponses.handleApiException;
+
 import com.cevapinxile.cestereg.core.service.SongService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -19,6 +19,7 @@ import java.util.UUID;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.ErrorResponse;
 import org.springframework.web.bind.annotation.CrossOrigin;
@@ -108,13 +109,12 @@ Workflow:
           UUID songId) {
     try {
       final byte[] content = songService.playSnippet(songId);
-      return ResponseEntity.ok().header("Accept-Ranges", "bytes").body(content);
-    } catch (DerivedException ex) {
-      LOG.info(ex.toString());
-      return ResponseEntity.status(ex.httpCode).body(ex.toString());
+      return ResponseEntity.ok()
+          .header("Accept-Ranges", "bytes")
+          .contentType(MediaType.valueOf("audio/mpeg"))
+          .body(content);
     } catch (Exception ex) {
-      LOG.error("Unexpected error", ex);
-      return ResponseEntity.status(500).body(new InternalServerErrorException());
+      return handleApiException(LOG, ex);
     }
   }
 
@@ -186,13 +186,12 @@ Workflow:
           UUID songId) {
     try {
       final byte[] content = songService.playAnswer(songId);
-      return ResponseEntity.ok().header("Accept-Ranges", "bytes").body(content);
-    } catch (DerivedException ex) {
-      LOG.info(ex.toString());
-      return ResponseEntity.status(ex.httpCode).body(ex.toString());
+      return ResponseEntity.ok()
+          .contentType(MediaType.valueOf("audio/mpeg"))
+          .header("Accept-Ranges", "bytes")
+          .body(content);
     } catch (Exception ex) {
-      LOG.error("Unexpected error", ex);
-      return ResponseEntity.status(500).body(new InternalServerErrorException());
+      return handleApiException(LOG, ex);
     }
   }
 }

--- a/apps/backend/src/main/java/com/cevapinxile/cestereg/api/quiz/controller/CategoryController.java
+++ b/apps/backend/src/main/java/com/cevapinxile/cestereg/api/quiz/controller/CategoryController.java
@@ -4,6 +4,8 @@
  */
 package com.cevapinxile.cestereg.api.quiz.controller;
 
+import static com.cevapinxile.cestereg.api.support.ApiErrorResponses.handleApiException;
+
 import com.cevapinxile.cestereg.api.quiz.dto.request.TeamIdRequest;
 import com.cevapinxile.cestereg.api.quiz.dto.response.LastCategory;
 import com.cevapinxile.cestereg.common.exception.DerivedException;
@@ -151,7 +153,7 @@ Workflow:
                             "{\"error\":\"E999 - Internal Server Error\","
                                 + "\"message\":\"Unexpected internal error.\"}")))
   })
-  @PutMapping("/{categoryId}/pick")
+  @PutMapping(value = "/{categoryId}/pick", produces = "application/json")
   public ResponseEntity<?> pickAlbum(
       @RoomCodePath @PathVariable String roomCode,
       @Parameter(
@@ -170,7 +172,7 @@ Workflow:
       return ResponseEntity.status(ex.httpCode).body(ex.toString());
     } catch (Exception ex) {
       LOG.error("Unexpected error", ex);
-      return ResponseEntity.status(500).body(new InternalServerErrorException());
+      return ResponseEntity.status(500).body(new InternalServerErrorException().toString());
     }
   }
 
@@ -252,12 +254,8 @@ Workflow:
     try {
       categoryService.startCategory(categoryId, roomCode);
       return ResponseEntity.ok().build();
-    } catch (DerivedException ex) {
-      LOG.info(ex.toString());
-      return ResponseEntity.status(ex.httpCode).body(ex.toString());
     } catch (Exception ex) {
-      LOG.error("Unexpected error", ex);
-      return ResponseEntity.status(500).body(new InternalServerErrorException());
+      return handleApiException(LOG, ex);
     }
   }
 }

--- a/apps/backend/src/main/java/com/cevapinxile/cestereg/api/quiz/controller/GameController.java
+++ b/apps/backend/src/main/java/com/cevapinxile/cestereg/api/quiz/controller/GameController.java
@@ -4,6 +4,8 @@
  */
 package com.cevapinxile.cestereg.api.quiz.controller;
 
+import static com.cevapinxile.cestereg.api.support.ApiErrorResponses.handleApiException;
+
 import com.cevapinxile.cestereg.api.quiz.dto.request.CreateGameRequest;
 import com.cevapinxile.cestereg.api.quiz.dto.request.StageIdRequest;
 import com.cevapinxile.cestereg.api.quiz.dto.response.RoomCodeResponse;
@@ -90,7 +92,7 @@ Workflow:
                             "{\"error\":\"E999 - Internal Server Error\","
                                 + "\"message\":\"Unexpected internal error.\"}")))
   })
-  @PostMapping
+  @PostMapping(produces = "application/json")
   public ResponseEntity<?> createGame(@RequestBody CreateGameRequest cgr) {
     try {
       return ResponseEntity.ok(new RoomCodeResponse(gameService.createGame(cgr)));
@@ -99,7 +101,7 @@ Workflow:
       return ResponseEntity.status(ex.httpCode).body(ex.toString());
     } catch (Exception ex) {
       LOG.error("Unexpected error", ex);
-      return ResponseEntity.status(500).body(new InternalServerErrorException());
+      return ResponseEntity.status(500).body(new InternalServerErrorException().toString());
     }
   }
 
@@ -173,12 +175,8 @@ Workflow:
     try {
       gameService.changeStage(stageId.stageId(), roomCode);
       return ResponseEntity.ok().build();
-    } catch (DerivedException ex) {
-      LOG.info(ex.toString());
-      return ResponseEntity.status(ex.httpCode).body(ex.toString());
     } catch (Exception ex) {
-      LOG.error("Unexpected error", ex);
-      return ResponseEntity.status(500).body(new InternalServerErrorException());
+      return handleApiException(LOG, ex);
     }
   }
 }

--- a/apps/backend/src/main/java/com/cevapinxile/cestereg/api/quiz/controller/InterruptController.java
+++ b/apps/backend/src/main/java/com/cevapinxile/cestereg/api/quiz/controller/InterruptController.java
@@ -4,12 +4,12 @@
  */
 package com.cevapinxile.cestereg.api.quiz.controller;
 
+import static com.cevapinxile.cestereg.api.support.ApiErrorResponses.handleApiException;
+
 import com.cevapinxile.cestereg.api.quiz.dto.request.AnswerRequest;
 import com.cevapinxile.cestereg.api.quiz.dto.request.ScenarioRequest;
 import com.cevapinxile.cestereg.api.quiz.dto.request.ScheduleIdRequest;
 import com.cevapinxile.cestereg.api.quiz.dto.request.TeamIdRequest;
-import com.cevapinxile.cestereg.common.exception.DerivedException;
-import com.cevapinxile.cestereg.common.exception.InternalServerErrorException;
 import com.cevapinxile.cestereg.common.util.RoomCodePath;
 import com.cevapinxile.cestereg.core.service.InterruptService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -121,12 +121,8 @@ Workflow:
     try {
       interruptService.interrupt(roomCode, tir.teamId());
       return ResponseEntity.ok().build();
-    } catch (DerivedException ex) {
-      LOG.info(ex.toString());
-      return ResponseEntity.status(ex.httpCode).body(ex.toString());
     } catch (Exception ex) {
-      LOG.error("Unexpected error", ex);
-      return ResponseEntity.status(500).body(new InternalServerErrorException());
+      return handleApiException(LOG, ex);
     }
   }
 
@@ -200,12 +196,8 @@ Workflow:
     try {
       interruptService.resolveErrors(sir.scheduleId(), roomCode);
       return ResponseEntity.ok().build();
-    } catch (DerivedException ex) {
-      LOG.info(ex.toString());
-      return ResponseEntity.status(ex.httpCode).body(ex.toString());
     } catch (Exception ex) {
-      LOG.error("Unexpected error", ex);
-      return ResponseEntity.status(500).body(new InternalServerErrorException());
+      return handleApiException(LOG, ex);
     }
   }
 
@@ -302,12 +294,8 @@ Workflow:
     try {
       interruptService.answer(answerId, ar, roomCode);
       return ResponseEntity.ok().build();
-    } catch (DerivedException ex) {
-      LOG.info(ex.toString());
-      return ResponseEntity.status(ex.httpCode).body(ex.toString());
     } catch (Exception ex) {
-      LOG.error("Unexpected error", ex);
-      return ResponseEntity.status(500).body(new InternalServerErrorException());
+      return handleApiException(LOG, ex);
     }
   }
 
@@ -381,12 +369,8 @@ Workflow:
     try {
       interruptService.savePreviousScenario(sr.scenario(), roomCode);
       return ResponseEntity.ok().build();
-    } catch (DerivedException ex) {
-      LOG.info(ex.toString());
-      return ResponseEntity.status(ex.httpCode).body(ex.toString());
     } catch (Exception ex) {
-      LOG.error("Unexpected error", ex);
-      return ResponseEntity.status(500).body(new InternalServerErrorException());
+      return handleApiException(LOG, ex);
     }
   }
 }

--- a/apps/backend/src/main/java/com/cevapinxile/cestereg/api/quiz/controller/ScheduleController.java
+++ b/apps/backend/src/main/java/com/cevapinxile/cestereg/api/quiz/controller/ScheduleController.java
@@ -4,8 +4,8 @@
  */
 package com.cevapinxile.cestereg.api.quiz.controller;
 
-import com.cevapinxile.cestereg.common.exception.DerivedException;
-import com.cevapinxile.cestereg.common.exception.InternalServerErrorException;
+import static com.cevapinxile.cestereg.api.support.ApiErrorResponses.handleApiException;
+
 import com.cevapinxile.cestereg.common.util.RoomCodePath;
 import com.cevapinxile.cestereg.core.service.ScheduleService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -119,12 +119,8 @@ Workflow:
     try {
       scheduleService.replaySong(scheduleId, roomCode);
       return ResponseEntity.ok().build();
-    } catch (DerivedException ex) {
-      LOG.info(ex.toString());
-      return ResponseEntity.status(ex.httpCode).body(ex.toString());
     } catch (Exception ex) {
-      LOG.error("Unexpected error", ex);
-      return ResponseEntity.status(500).body(new InternalServerErrorException());
+      return handleApiException(LOG, ex);
     }
   }
 
@@ -205,12 +201,8 @@ Workflow:
     try {
       scheduleService.revealAnswer(scheduleId, roomCode);
       return ResponseEntity.ok().build();
-    } catch (DerivedException ex) {
-      LOG.info(ex.toString());
-      return ResponseEntity.status(ex.httpCode).body(ex.toString());
     } catch (Exception ex) {
-      LOG.error("Unexpected error", ex);
-      return ResponseEntity.status(500).body(new InternalServerErrorException());
+      return handleApiException(LOG, ex);
     }
   }
 
@@ -288,12 +280,8 @@ Workflow:
     try {
       scheduleService.progress(roomCode);
       return ResponseEntity.ok().build();
-    } catch (DerivedException ex) {
-      LOG.info(ex.toString());
-      return ResponseEntity.status(ex.httpCode).body(ex.toString());
     } catch (Exception ex) {
-      LOG.error("Unexpected error", ex);
-      return ResponseEntity.status(500).body(new InternalServerErrorException());
+      return handleApiException(LOG, ex);
     }
   }
 }

--- a/apps/backend/src/main/java/com/cevapinxile/cestereg/api/quiz/controller/TeamController.java
+++ b/apps/backend/src/main/java/com/cevapinxile/cestereg/api/quiz/controller/TeamController.java
@@ -4,6 +4,8 @@
  */
 package com.cevapinxile.cestereg.api.quiz.controller;
 
+import static com.cevapinxile.cestereg.api.support.ApiErrorResponses.handleApiException;
+
 import com.cevapinxile.cestereg.api.quiz.dto.request.CreateTeamRequest;
 import com.cevapinxile.cestereg.api.quiz.dto.response.CreateTeamResponse;
 import com.cevapinxile.cestereg.common.exception.DerivedException;
@@ -128,7 +130,7 @@ Notes:
                             "{\"error\":\"E999 - Internal Server Error\","
                                 + "\"message\":\"Unexpected internal error.\"}")))
   })
-  @PostMapping
+  @PostMapping(produces = "application/json")
   public ResponseEntity<?> createTeam(
       @RoomCodePath @PathVariable String roomCode, @RequestBody CreateTeamRequest ctr) {
     try {
@@ -138,7 +140,7 @@ Notes:
       return ResponseEntity.status(ex.httpCode).body(ex.toString());
     } catch (Exception ex) {
       LOG.error("Unexpected error", ex);
-      return ResponseEntity.status(500).body(new InternalServerErrorException());
+      return ResponseEntity.status(500).body(new InternalServerErrorException().toString());
     }
   }
 
@@ -206,12 +208,8 @@ Workflow:
     try {
       teamService.kickTeam(teamId, roomCode);
       return ResponseEntity.ok().build();
-    } catch (DerivedException ex) {
-      LOG.info(ex.toString());
-      return ResponseEntity.status(ex.httpCode).body(ex.toString());
     } catch (Exception ex) {
-      LOG.error("Unexpected error", ex);
-      return ResponseEntity.status(500).body(new InternalServerErrorException());
+      return handleApiException(LOG, ex);
     }
   }
 }

--- a/apps/backend/src/main/java/com/cevapinxile/cestereg/api/support/ApiErrorResponses.java
+++ b/apps/backend/src/main/java/com/cevapinxile/cestereg/api/support/ApiErrorResponses.java
@@ -1,0 +1,40 @@
+/*
+ * Click nbfs://nbhost/SystemFileSystem/Templates/Licenses/license-default.txt to change this license
+ * Click nbfs://nbhost/SystemFileSystem/Templates/Classes/Class.java to edit this template
+ */
+package com.cevapinxile.cestereg.api.support;
+
+/**
+ * @author denijal
+ */
+import com.cevapinxile.cestereg.common.exception.DerivedException;
+import com.cevapinxile.cestereg.common.exception.InternalServerErrorException;
+import org.slf4j.Logger;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+
+public final class ApiErrorResponses {
+
+  private ApiErrorResponses() {}
+
+  public static ResponseEntity<String> handleApiException(Logger log, Exception ex) {
+    if (ex instanceof DerivedException derivedException) {
+      return fromDerived(log, derivedException);
+    }
+    return fromUnexpected(log, ex);
+  }
+
+  private static ResponseEntity<String> fromDerived(Logger log, DerivedException ex) {
+    log.info(ex.toString());
+    return ResponseEntity.status(ex.httpCode)
+        .contentType(MediaType.APPLICATION_JSON)
+        .body(ex.toString());
+  }
+
+  private static ResponseEntity<String> fromUnexpected(Logger log, Exception ex) {
+    log.error("Unexpected error", ex);
+    return ResponseEntity.status(500)
+        .contentType(MediaType.APPLICATION_JSON)
+        .body(new InternalServerErrorException().toString());
+  }
+}

--- a/apps/backend/src/main/java/com/cevapinxile/cestereg/common/exception/DerivedException.java
+++ b/apps/backend/src/main/java/com/cevapinxile/cestereg/common/exception/DerivedException.java
@@ -59,6 +59,6 @@ public class DerivedException extends Exception {
    */
   @Override
   public String toString() {
-    return "{\"error\":\"E" + errorCode + " - " + title + "\" ,\"message\":\"" + message + "\"}";
+    return "{\"error\":\"E" + errorCode + " - " + title + "\", \"message\":\"" + message + "\"}";
   }
 }

--- a/apps/backend/src/test/java/com/cevapinxile/cestereg/api/assets/controller/AudioAssetControllerTest.java
+++ b/apps/backend/src/test/java/com/cevapinxile/cestereg/api/assets/controller/AudioAssetControllerTest.java
@@ -1,0 +1,207 @@
+package com.cevapinxile.cestereg.api.assets.controller;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+import static org.springframework.http.MediaType.APPLICATION_JSON;
+import static org.springframework.http.MediaType.parseMediaType;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.options;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.cevapinxile.cestereg.api.support.ControllerTestSupport;
+import com.cevapinxile.cestereg.core.service.SongService;
+import java.nio.charset.StandardCharsets;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(AudioAssetController.class)
+class AudioAssetControllerTest extends ControllerTestSupport {
+
+  @Autowired private MockMvc mockMvc;
+
+  @MockitoBean private SongService songService;
+
+  @Test
+  void playSnippetReturnsAudioBytesAndRangeHeader() throws Exception {
+    UUID songId = UUID.randomUUID();
+    byte[] payload = "snippet-bytes".getBytes(StandardCharsets.UTF_8);
+    when(songService.playSnippet(songId)).thenReturn(payload);
+
+    mockMvc
+        .perform(get("/assets/v1/audio/snippets/{songId}", songId))
+        .andExpect(status().isOk())
+        .andExpect(content().contentType(parseMediaType("audio/mpeg")))
+        .andExpect(header().string("Accept-Ranges", "bytes"))
+        .andExpect(content().bytes(payload));
+
+    verify(songService).playSnippet(songId);
+  }
+
+  @Test
+  void playSnippetMapsDerivedExceptionStatusAndBody() throws Exception {
+    UUID songId = UUID.randomUUID();
+    when(songService.playSnippet(songId))
+        .thenThrow(derived(404, "001", "Invalid referenced object", "Snippet missing"));
+
+    mockMvc
+        .perform(get("/assets/v1/audio/snippets/{songId}", songId))
+        .andExpect(status().isNotFound())
+        .andExpect(content().contentTypeCompatibleWith(APPLICATION_JSON))
+        .andExpect(
+            content()
+                .string(
+                    "{\"error\":\"E001 - Invalid referenced object\", \"message\":\"Snippet missing\"}"));
+  }
+
+  @Test
+  void playSnippetReturnsInternalServerErrorForUnexpectedException() throws Exception {
+    UUID songId = UUID.randomUUID();
+    when(songService.playSnippet(songId)).thenThrow(new RuntimeException("boom"));
+
+    mockMvc
+        .perform(get("/assets/v1/audio/snippets/{songId}", songId))
+        .andExpect(status().isInternalServerError())
+        .andExpect(content().contentTypeCompatibleWith(APPLICATION_JSON))
+        .andExpect(content().string(containsString("Unexpected internal error")));
+  }
+
+  @Test
+  void playSnippetAddsCorsHeaderWhenOriginPresent() throws Exception {
+    UUID songId = UUID.randomUUID();
+    when(songService.playSnippet(songId)).thenReturn(new byte[] {1, 2, 3});
+
+    mockMvc
+        .perform(
+            get("/assets/v1/audio/snippets/{songId}", songId)
+                .header("Origin", "https://example.com"))
+        .andExpect(status().isOk())
+        .andExpect(header().string("Access-Control-Allow-Origin", "*"));
+  }
+
+  @Test
+  void playAnswerReturnsAudioBytesAndRangeHeader() throws Exception {
+    UUID songId = UUID.randomUUID();
+    byte[] payload = "answer-bytes".getBytes(StandardCharsets.UTF_8);
+    when(songService.playAnswer(songId)).thenReturn(payload);
+
+    mockMvc
+        .perform(get("/assets/v1/audio/answers/{songId}", songId))
+        .andExpect(status().isOk())
+        .andExpect(content().contentType(parseMediaType("audio/mpeg")))
+        .andExpect(header().string("Accept-Ranges", "bytes"))
+        .andExpect(content().bytes(payload));
+
+    verify(songService).playAnswer(songId);
+  }
+
+  @Test
+  void playAnswerMapsDerivedExceptionStatusAndBody() throws Exception {
+    UUID songId = UUID.randomUUID();
+    when(songService.playAnswer(songId))
+        .thenThrow(derived(503, "004", "App not reachable", "Answer exists but could not be read"));
+
+    mockMvc
+        .perform(get("/assets/v1/audio/answers/{songId}", songId))
+        .andExpect(status().isServiceUnavailable())
+        .andExpect(content().contentTypeCompatibleWith(APPLICATION_JSON))
+        .andExpect(
+            content()
+                .string(
+                    "{\"error\":\"E004 - App not reachable\", \"message\":\"Answer exists but could not be read\"}"));
+  }
+
+  @Test
+  void playAnswerReturnsInternalServerErrorForUnexpectedException() throws Exception {
+    UUID songId = UUID.randomUUID();
+    when(songService.playAnswer(songId)).thenThrow(new RuntimeException("boom"));
+
+    mockMvc
+        .perform(get("/assets/v1/audio/answers/{songId}", songId))
+        .andExpect(status().isInternalServerError())
+        .andExpect(content().contentTypeCompatibleWith(APPLICATION_JSON))
+        .andExpect(content().string(containsString("Unexpected internal error")));
+  }
+
+  @Test
+  void playAnswerAddsCorsHeaderWhenOriginPresent() throws Exception {
+    UUID songId = UUID.randomUUID();
+    when(songService.playAnswer(songId)).thenReturn(new byte[] {4, 5, 6});
+
+    mockMvc
+        .perform(
+            get("/assets/v1/audio/answers/{songId}", songId)
+                .header("Origin", "https://example.com"))
+        .andExpect(status().isOk())
+        .andExpect(header().string("Access-Control-Allow-Origin", "*"));
+  }
+
+  @Test
+  void snippetRejectsUnsupportedHttpMethod() throws Exception {
+    mockMvc
+        .perform(post("/assets/v1/audio/snippets/{songId}", UUID.randomUUID()))
+        .andExpect(status().isMethodNotAllowed());
+    verifyNoInteractions(songService);
+  }
+
+  @Test
+  void answerRejectsUnsupportedHttpMethod() throws Exception {
+    mockMvc
+        .perform(post("/assets/v1/audio/answers/{songId}", UUID.randomUUID()))
+        .andExpect(status().isMethodNotAllowed());
+    verifyNoInteractions(songService);
+  }
+
+  @Test
+  void snippetOptionsPreflightIncludesCorsHeaders() throws Exception {
+    mockMvc
+        .perform(
+            options("/assets/v1/audio/snippets/{songId}", UUID.randomUUID())
+                .header("Origin", "https://example.com")
+                .header("Access-Control-Request-Method", "GET"))
+        .andExpect(status().isOk())
+        .andExpect(header().string("Access-Control-Allow-Origin", "*"));
+  }
+
+  @Test
+  void answerOptionsPreflightIncludesCorsHeaders() throws Exception {
+    mockMvc
+        .perform(
+            options("/assets/v1/audio/answers/{songId}", UUID.randomUUID())
+                .header("Origin", "https://example.com")
+                .header("Access-Control-Request-Method", "GET"))
+        .andExpect(status().isOk())
+        .andExpect(header().string("Access-Control-Allow-Origin", "*"));
+  }
+
+  @Test
+  void snippetResponseDoesNotPretendToBeJson() throws Exception {
+    UUID id = UUID.randomUUID();
+    when(songService.playSnippet(id)).thenReturn(new byte[] {1, 2, 3});
+
+    mockMvc
+        .perform(get("/assets/v1/audio/snippets/{songId}", id))
+        .andExpect(status().isOk())
+        .andExpect(header().string("Content-Type", parseMediaType("audio/mpeg").toString()));
+  }
+
+  @Test
+  void malformedSnippetUuidDoesNotCallService() throws Exception {
+    mockMvc.perform(get("/assets/v1/audio/snippets/not-a-uuid")).andExpect(status().isBadRequest());
+    verifyNoInteractions(songService);
+  }
+
+  @Test
+  void malformedAnswerUuidDoesNotCallService() throws Exception {
+    mockMvc.perform(get("/assets/v1/audio/answers/not-a-uuid")).andExpect(status().isBadRequest());
+    verifyNoInteractions(songService);
+  }
+}

--- a/apps/backend/src/test/java/com/cevapinxile/cestereg/api/quiz/controller/CategoryControllerTest.java
+++ b/apps/backend/src/test/java/com/cevapinxile/cestereg/api/quiz/controller/CategoryControllerTest.java
@@ -1,0 +1,446 @@
+package com.cevapinxile.cestereg.api.quiz.controller;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+import static org.springframework.http.MediaType.APPLICATION_JSON;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.options;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.cevapinxile.cestereg.api.quiz.dto.request.TeamIdRequest;
+import com.cevapinxile.cestereg.api.quiz.dto.response.CategoryPreview;
+import com.cevapinxile.cestereg.api.quiz.dto.response.CreateTeamResponse;
+import com.cevapinxile.cestereg.api.quiz.dto.response.LastCategory;
+import com.cevapinxile.cestereg.api.support.ControllerTestSupport;
+import com.cevapinxile.cestereg.core.service.CategoryService;
+import java.util.UUID;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.ArgumentCaptor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(CategoryController.class)
+class CategoryControllerTest extends ControllerTestSupport {
+
+  @Autowired private MockMvc mockMvc;
+
+  @MockitoBean private CategoryService categoryService;
+
+  @Nested
+  class PickAlbumTests {
+
+    @Test
+    void pickAlbumReturnsSerializedLastCategory() throws Exception {
+      UUID categoryId = UUID.randomUUID();
+      UUID teamId = UUID.randomUUID();
+      LastCategory response = new LastCategory();
+      response.setCategoryId(categoryId);
+      response.setChosenCategoryPreview(new CategoryPreview("Best of 2000s", "cat.png"));
+      response.setPickedByTeam(new CreateTeamResponse(teamId, "Team Cyan", "team.png"));
+      response.setStarted(true);
+      response.setOrdinalNumber(7);
+
+      when(categoryService.pickAlbum(eq(categoryId), any(), eq("AKKU"))).thenReturn(response);
+
+      mockMvc
+          .perform(
+              put("/api/v1/games/{roomCode}/categories/{categoryId}/pick", "AKKU", categoryId)
+                  .contentType(APPLICATION_JSON)
+                  .content("{\"teamId\":\"" + teamId + "\"}"))
+          .andExpect(status().isOk())
+          .andExpect(content().contentTypeCompatibleWith(APPLICATION_JSON))
+          .andExpect(jsonPath("$.categoryId").value(categoryId.toString()))
+          .andExpect(jsonPath("$.chosenCategoryPreview.title").value("Best of 2000s"))
+          .andExpect(jsonPath("$.chosenCategoryPreview.image").value("cat.png"))
+          .andExpect(jsonPath("$.pickedByTeam.id").value(teamId.toString()))
+          .andExpect(jsonPath("$.pickedByTeam.name").value("Team Cyan"))
+          .andExpect(jsonPath("$.pickedByTeam.image").value("team.png"))
+          .andExpect(jsonPath("$.started").value(true))
+          .andExpect(jsonPath("$.ordinalNumber").value(7));
+
+      ArgumentCaptor<TeamIdRequest> captor = ArgumentCaptor.forClass(TeamIdRequest.class);
+      verify(categoryService).pickAlbum(eq(categoryId), captor.capture(), eq("AKKU"));
+      assertEquals(teamId, captor.getValue().teamId());
+    }
+
+    @Test
+    void pickAlbumReturnsBadRequestForMissingBody() throws Exception {
+      mockMvc
+          .perform(
+              put(
+                  "/api/v1/games/{roomCode}/categories/{categoryId}/pick",
+                  "AKKU",
+                  UUID.randomUUID()))
+          .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void pickAlbumReturnsBadRequestForMalformedCategoryUuid() throws Exception {
+      mockMvc
+          .perform(
+              put("/api/v1/games/{roomCode}/categories/{categoryId}/pick", "AKKU", "not-a-uuid")
+                  .contentType(APPLICATION_JSON)
+                  .content("{\"teamId\":null}"))
+          .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void pickAlbumForwardsNullTeamIdWhenPayloadOmitsIt() throws Exception {
+      UUID categoryId = UUID.randomUUID();
+      when(categoryService.pickAlbum(eq(categoryId), any(), eq("AKKU")))
+          .thenReturn(new LastCategory());
+
+      mockMvc
+          .perform(
+              put("/api/v1/games/{roomCode}/categories/{categoryId}/pick", "AKKU", categoryId)
+                  .contentType(APPLICATION_JSON)
+                  .content("{}"))
+          .andExpect(status().isOk())
+          .andExpect(content().contentTypeCompatibleWith(APPLICATION_JSON));
+
+      ArgumentCaptor<TeamIdRequest> captor = ArgumentCaptor.forClass(TeamIdRequest.class);
+      verify(categoryService).pickAlbum(eq(categoryId), captor.capture(), eq("AKKU"));
+      assertNull(captor.getValue().teamId());
+    }
+
+    @Test
+    void pickAlbumDoesNotValidateRoomCodeFormatAtControllerLevel() throws Exception {
+      UUID categoryId = UUID.randomUUID();
+      when(categoryService.pickAlbum(eq(categoryId), any(), eq("abc")))
+          .thenReturn(new LastCategory());
+
+      mockMvc
+          .perform(
+              put("/api/v1/games/{roomCode}/categories/{categoryId}/pick", "abc", categoryId)
+                  .contentType(APPLICATION_JSON)
+                  .content("{\"teamId\":null}"))
+          .andExpect(status().isOk());
+
+      verify(categoryService).pickAlbum(eq(categoryId), any(), eq("abc"));
+    }
+
+    @ParameterizedTest
+    @MethodSource("derivedExceptionsForPickAlbum")
+    void pickAlbumMapsDerivedExceptions(int status, String code, String title, String message)
+        throws Exception {
+      UUID categoryId = UUID.randomUUID();
+      when(categoryService.pickAlbum(eq(categoryId), any(), eq("AKKU")))
+          .thenThrow(derived(status, code, title, message));
+
+      mockMvc
+          .perform(
+              put("/api/v1/games/{roomCode}/categories/{categoryId}/pick", "AKKU", categoryId)
+                  .contentType(APPLICATION_JSON)
+                  .content("{\"teamId\":null}"))
+          .andExpect(status().is(status))
+          .andExpect(content().contentTypeCompatibleWith(APPLICATION_JSON))
+          .andExpect(
+              content()
+                  .string(
+                      "{\"error\":\"E"
+                          + code
+                          + " - "
+                          + title
+                          + "\", \"message\":\""
+                          + message
+                          + "\"}"));
+    }
+
+    @Test
+    void pickAlbumReturnsInternalServerErrorForUnexpectedException() throws Exception {
+      UUID categoryId = UUID.randomUUID();
+      when(categoryService.pickAlbum(eq(categoryId), any(), eq("AKKU")))
+          .thenThrow(new RuntimeException("boom"));
+
+      mockMvc
+          .perform(
+              put("/api/v1/games/{roomCode}/categories/{categoryId}/pick", "AKKU", categoryId)
+                  .contentType(APPLICATION_JSON)
+                  .content("{\"teamId\":null}"))
+          .andExpect(status().isInternalServerError())
+          .andExpect(content().contentTypeCompatibleWith(APPLICATION_JSON));
+    }
+
+    @Test
+    void pickAlbumAddsCorsHeaderWhenOriginPresent() throws Exception {
+      UUID categoryId = UUID.randomUUID();
+      when(categoryService.pickAlbum(eq(categoryId), any(), eq("AKKU")))
+          .thenReturn(new LastCategory());
+
+      mockMvc
+          .perform(
+              put("/api/v1/games/{roomCode}/categories/{categoryId}/pick", "AKKU", categoryId)
+                  .header("Origin", "https://example.com")
+                  .contentType(APPLICATION_JSON)
+                  .content("{\"teamId\":null}"))
+          .andExpect(status().isOk())
+          .andExpect(header().string("Access-Control-Allow-Origin", "*"));
+    }
+
+    static Stream<Arguments> derivedExceptionsForPickAlbum() {
+      return Stream.of(
+          Arguments.of(400, "000", "An argument is missing", "teamId is required."),
+          Arguments.of(
+              422, "002", "Malformed argument", "Request body must contain a valid teamId."),
+          Arguments.of(
+              404, "001", "Invalid referenced object", "Game, team, or category not found."),
+          Arguments.of(
+              409, "003", "Wrong game-state", "Category picking is only allowed in stage 1."),
+          Arguments.of(503, "004", "App not reachable", "TV app is not reachable."));
+    }
+  }
+
+  @Nested
+  class StartCategoryTests {
+
+    @Test
+    void startCategoryReturnsOk() throws Exception {
+      UUID categoryId = UUID.randomUUID();
+
+      mockMvc
+          .perform(
+              post("/api/v1/games/{roomCode}/categories/{categoryId}/start", "AKKU", categoryId))
+          .andExpect(status().isOk())
+          .andExpect(content().string(""));
+
+      verify(categoryService).startCategory(categoryId, "AKKU");
+    }
+
+    @Test
+    void startCategoryDoesNotValidateRoomCodeFormatAtControllerLevel() throws Exception {
+      UUID categoryId = UUID.randomUUID();
+
+      mockMvc
+          .perform(
+              post("/api/v1/games/{roomCode}/categories/{categoryId}/start", "abc", categoryId))
+          .andExpect(status().isOk());
+
+      verify(categoryService).startCategory(categoryId, "abc");
+    }
+
+    @ParameterizedTest
+    @MethodSource("derivedExceptionsForStartCategory")
+    void startCategoryMapsDerivedExceptions(int status, String code, String title, String message)
+        throws Exception {
+      UUID categoryId = UUID.randomUUID();
+      doThrow(derived(status, code, title, message))
+          .when(categoryService)
+          .startCategory(categoryId, "AKKU");
+
+      mockMvc
+          .perform(
+              post("/api/v1/games/{roomCode}/categories/{categoryId}/start", "AKKU", categoryId))
+          .andExpect(status().is(status))
+          .andExpect(content().contentTypeCompatibleWith(APPLICATION_JSON))
+          .andExpect(
+              content()
+                  .string(
+                      "{\"error\":\"E"
+                          + code
+                          + " - "
+                          + title
+                          + "\", \"message\":\""
+                          + message
+                          + "\"}"));
+    }
+
+    @Test
+    void startCategoryReturnsInternalServerErrorForUnexpectedException() throws Exception {
+      UUID categoryId = UUID.randomUUID();
+      doThrow(new RuntimeException("boom")).when(categoryService).startCategory(categoryId, "AKKU");
+
+      mockMvc
+          .perform(
+              post("/api/v1/games/{roomCode}/categories/{categoryId}/start", "AKKU", categoryId))
+          .andExpect(status().isInternalServerError())
+          .andExpect(content().contentTypeCompatibleWith(APPLICATION_JSON));
+    }
+
+    @Test
+    void startCategoryAddsCorsHeaderWhenOriginPresent() throws Exception {
+      UUID categoryId = UUID.randomUUID();
+
+      mockMvc
+          .perform(
+              post("/api/v1/games/{roomCode}/categories/{categoryId}/start", "AKKU", categoryId)
+                  .header("Origin", "https://example.com"))
+          .andExpect(status().isOk())
+          .andExpect(header().string("Access-Control-Allow-Origin", "*"));
+    }
+
+    static Stream<Arguments> derivedExceptionsForStartCategory() {
+      return Stream.of(
+          Arguments.of(
+              422, "002", "Malformed argument", "Category exists but is not part of the game."),
+          Arguments.of(404, "001", "Invalid referenced object", "Category not found."),
+          Arguments.of(
+              409, "003", "Wrong game-state", "Starting a category is only allowed in stage 1."));
+    }
+  }
+
+  @Nested
+  class PickAlbumContract {
+
+    @Test
+    void pickAlbumRejectsUnsupportedMethod() throws Exception {
+      mockMvc
+          .perform(
+              delete(
+                  "/api/v1/games/{roomCode}/categories/{categoryId}/pick",
+                  "AKKU",
+                  UUID.randomUUID()))
+          .andExpect(status().isMethodNotAllowed());
+      verifyNoInteractions(categoryService);
+    }
+
+    @Test
+    void pickAlbumRejectsUnsupportedMediaType() throws Exception {
+      mockMvc
+          .perform(
+              put(
+                      "/api/v1/games/{roomCode}/categories/{categoryId}/pick",
+                      "AKKU",
+                      UUID.randomUUID())
+                  .contentType("text/plain")
+                  .content("x"))
+          .andExpect(status().isUnsupportedMediaType());
+      verifyNoInteractions(categoryService);
+    }
+
+    @Test
+    void pickAlbumMalformedJsonDoesNotCallService() throws Exception {
+      mockMvc
+          .perform(
+              put(
+                      "/api/v1/games/{roomCode}/categories/{categoryId}/pick",
+                      "AKKU",
+                      UUID.randomUUID())
+                  .contentType(APPLICATION_JSON)
+                  .content("{\"teamId\":"))
+          .andExpect(status().isBadRequest());
+      verifyNoInteractions(categoryService);
+    }
+
+    @Test
+    void pickAlbumPreflightReturnsCorsHeaders() throws Exception {
+      mockMvc
+          .perform(
+              options(
+                      "/api/v1/games/{roomCode}/categories/{categoryId}/pick",
+                      "AKKU",
+                      UUID.randomUUID())
+                  .header("Origin", "https://example.com")
+                  .header("Access-Control-Request-Method", "PUT"))
+          .andExpect(status().isOk())
+          .andExpect(header().string("Access-Control-Allow-Origin", "*"));
+    }
+  }
+
+  @Nested
+  class StartCategoryContract {
+
+    @Test
+    void startCategoryRejectsUnsupportedMethod() throws Exception {
+      mockMvc
+          .perform(
+              put(
+                  "/api/v1/games/{roomCode}/categories/{categoryId}/start",
+                  "AKKU",
+                  UUID.randomUUID()))
+          .andExpect(status().isMethodNotAllowed());
+      verifyNoInteractions(categoryService);
+    }
+
+    @Test
+    void startCategoryPreflightReturnsCorsHeaders() throws Exception {
+      mockMvc
+          .perform(
+              options(
+                      "/api/v1/games/{roomCode}/categories/{categoryId}/start",
+                      "AKKU",
+                      UUID.randomUUID())
+                  .header("Origin", "https://example.com")
+                  .header("Access-Control-Request-Method", "POST"))
+          .andExpect(status().isOk())
+          .andExpect(header().string("Access-Control-Allow-Origin", "*"));
+    }
+
+    @Test
+    void malformedCategoryIdDoesNotCallService() throws Exception {
+      mockMvc
+          .perform(
+              post("/api/v1/games/{roomCode}/categories/{categoryId}/start", "AKKU", "not-a-uuid"))
+          .andExpect(status().isBadRequest());
+      verifyNoInteractions(categoryService);
+    }
+  }
+
+  @Nested
+  class PickAlbumBinding {
+
+    @Test
+    void pickAlbumRejectsNumericTeamId() throws Exception {
+      mockMvc
+          .perform(
+              put(
+                      "/api/v1/games/{roomCode}/categories/{categoryId}/pick",
+                      "AKKU",
+                      UUID.randomUUID())
+                  .contentType(APPLICATION_JSON)
+                  .content("{\"teamId\":123}"))
+          .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void pickAlbumAllowsExplicitNullTeamIdAndForwardsIt() throws Exception {
+      UUID categoryId = UUID.randomUUID();
+
+      when(categoryService.pickAlbum(eq(categoryId), any(), eq("AKKU")))
+          .thenReturn(new LastCategory());
+
+      mockMvc
+          .perform(
+              put("/api/v1/games/{roomCode}/categories/{categoryId}/pick", "AKKU", categoryId)
+                  .contentType(APPLICATION_JSON)
+                  .content("{\"teamId\":null}"))
+          .andExpect(status().isOk());
+
+      ArgumentCaptor<TeamIdRequest> captor = ArgumentCaptor.forClass(TeamIdRequest.class);
+      verify(categoryService).pickAlbum(eq(categoryId), captor.capture(), eq("AKKU"));
+      Assertions.assertNull(captor.getValue().teamId());
+    }
+
+    @Test
+    void pickAlbumIgnoresUnknownFieldsWhenMainPayloadIsValid() throws Exception {
+      UUID categoryId = UUID.randomUUID();
+      when(categoryService.pickAlbum(eq(categoryId), any(), eq("AKKU")))
+          .thenReturn(new LastCategory());
+
+      mockMvc
+          .perform(
+              put("/api/v1/games/{roomCode}/categories/{categoryId}/pick", "AKKU", categoryId)
+                  .contentType(APPLICATION_JSON)
+                  .content("{\"teamId\":\"" + UUID.randomUUID() + "\",\"extra\":\"ignored\"}"))
+          .andExpect(status().isOk());
+    }
+  }
+}

--- a/apps/backend/src/test/java/com/cevapinxile/cestereg/api/quiz/controller/GameControllerTest.java
+++ b/apps/backend/src/test/java/com/cevapinxile/cestereg/api/quiz/controller/GameControllerTest.java
@@ -1,0 +1,450 @@
+package com.cevapinxile.cestereg.api.quiz.controller;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+import static org.springframework.http.MediaType.APPLICATION_JSON;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.options;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.cevapinxile.cestereg.api.quiz.dto.request.CreateGameRequest;
+import com.cevapinxile.cestereg.api.support.ControllerTestSupport;
+import com.cevapinxile.cestereg.core.service.GameService;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.ArgumentCaptor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(GameController.class)
+class GameControllerTest extends ControllerTestSupport {
+
+  @Autowired private MockMvc mockMvc;
+
+  @MockitoBean private GameService gameService;
+
+  @Nested
+  class CreateGameTests {
+
+    @Test
+    void createGameReturnsRoomCodeResponse() throws Exception {
+      when(gameService.createGame(any())).thenReturn("AKKU");
+
+      mockMvc
+          .perform(
+              post("/api/v1/games")
+                  .contentType(APPLICATION_JSON)
+                  .content("{\"maxSongs\":10,\"maxAlbums\":3}"))
+          .andExpect(status().isOk())
+          .andExpect(content().contentTypeCompatibleWith(APPLICATION_JSON))
+          .andExpect(jsonPath("$.roomCode").value("AKKU"));
+
+      ArgumentCaptor<CreateGameRequest> captor = ArgumentCaptor.forClass(CreateGameRequest.class);
+      verify(gameService).createGame(captor.capture());
+      CreateGameRequest request = captor.getValue();
+      assertEquals(10, request.maxSongs());
+      assertEquals(3, request.maxAlbums());
+    }
+
+    @Test
+    void createGameReturnsBadRequestForMissingBody() throws Exception {
+      mockMvc.perform(post("/api/v1/games")).andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void createGameReturnsBadRequestForMalformedJson() throws Exception {
+      mockMvc
+          .perform(post("/api/v1/games").contentType(APPLICATION_JSON).content("{\"maxSongs\":"))
+          .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void createGameForwardsNullFieldsWhenPayloadOmitsParameters() throws Exception {
+      when(gameService.createGame(any())).thenReturn("AKKU");
+
+      mockMvc
+          .perform(post("/api/v1/games").contentType(APPLICATION_JSON).content("{}"))
+          .andExpect(status().isOk())
+          .andExpect(content().contentTypeCompatibleWith(APPLICATION_JSON));
+
+      ArgumentCaptor<CreateGameRequest> captor = ArgumentCaptor.forClass(CreateGameRequest.class);
+      verify(gameService).createGame(captor.capture());
+      assertNull(captor.getValue().maxSongs());
+      assertNull(captor.getValue().maxAlbums());
+    }
+
+    @ParameterizedTest
+    @MethodSource("derivedExceptionsForCreateGame")
+    void createGameMapsDerivedException(int status, String code, String title, String message)
+        throws Exception {
+      when(gameService.createGame(any())).thenThrow(derived(status, code, title, message));
+
+      mockMvc
+          .perform(
+              post("/api/v1/games")
+                  .contentType(APPLICATION_JSON)
+                  .content("{\"maxSongs\":10,\"maxAlbums\":3}"))
+          .andExpect(status().is(status))
+          .andExpect(content().contentTypeCompatibleWith(APPLICATION_JSON))
+          .andExpect(
+              content()
+                  .string(
+                      "{\"error\":\"E"
+                          + code
+                          + " - "
+                          + title
+                          + "\", \"message\":\""
+                          + message
+                          + "\"}"));
+    }
+
+    @Test
+    void createGameReturnsInternalServerErrorForUnexpectedException() throws Exception {
+      when(gameService.createGame(any())).thenThrow(new RuntimeException("boom"));
+
+      mockMvc
+          .perform(
+              post("/api/v1/games")
+                  .contentType(APPLICATION_JSON)
+                  .content("{\"maxSongs\":10,\"maxAlbums\":3}"))
+          .andExpect(status().isInternalServerError())
+          .andExpect(content().contentTypeCompatibleWith(APPLICATION_JSON));
+    }
+
+    @Test
+    void createGameAddsCorsHeaderWhenOriginPresent() throws Exception {
+      when(gameService.createGame(any())).thenReturn("AKKU");
+
+      mockMvc
+          .perform(
+              post("/api/v1/games")
+                  .header("Origin", "https://example.com")
+                  .contentType(APPLICATION_JSON)
+                  .content("{\"maxSongs\":10,\"maxAlbums\":3}"))
+          .andExpect(status().isOk())
+          .andExpect(header().string("Access-Control-Allow-Origin", "*"));
+    }
+
+    static Stream<Arguments> derivedExceptionsForCreateGame() {
+      return Stream.of(
+          Arguments.of(
+              422,
+              "002",
+              "Malformed argument",
+              "maxSongs and maxAlbums must be positive integers."));
+    }
+  }
+
+  @Nested
+  class ChangeStageTests {
+
+    @Test
+    void changeStageReturnsOkAndForwardsStageId() throws Exception {
+      mockMvc
+          .perform(
+              put("/api/v1/games/{roomCode}/stage", "AKKU")
+                  .contentType(APPLICATION_JSON)
+                  .content("{\"stageId\":2}"))
+          .andExpect(status().isOk())
+          .andExpect(content().string(""));
+
+      verify(gameService).changeStage(2, "AKKU");
+    }
+
+    @Test
+    void changeStageReturnsBadRequestForMissingBody() throws Exception {
+      mockMvc
+          .perform(put("/api/v1/games/{roomCode}/stage", "AKKU"))
+          .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void changeStageReturnsBadRequestForMalformedJson() throws Exception {
+      mockMvc
+          .perform(
+              put("/api/v1/games/{roomCode}/stage", "AKKU")
+                  .contentType(APPLICATION_JSON)
+                  .content("{\"stageId\":"))
+          .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void changeStageReturnsBadRequestWhenStageIdMissingFromPayload() throws Exception {
+      mockMvc
+          .perform(
+              put("/api/v1/games/{roomCode}/stage", "AKKU")
+                  .contentType(APPLICATION_JSON)
+                  .content("{}"))
+          .andExpect(status().isBadRequest());
+
+      verifyNoInteractions(gameService);
+    }
+
+    @Test
+    @DisplayName(
+        "RoomCodePath is documentation-only, so invalid room codes still reach the service")
+    void changeStageDoesNotRejectInvalidRoomCodeAtControllerLevel() throws Exception {
+      mockMvc
+          .perform(
+              put("/api/v1/games/{roomCode}/stage", "abc")
+                  .contentType(APPLICATION_JSON)
+                  .content("{\"stageId\":1}"))
+          .andExpect(status().isOk());
+
+      verify(gameService).changeStage(1, "abc");
+    }
+
+    @ParameterizedTest
+    @MethodSource("derivedExceptionsForChangeStage")
+    void changeStageMapsDerivedException(int status, String code, String title, String message)
+        throws Exception {
+
+      doThrow(derived(status, code, title, message)).when(gameService).changeStage(2, "AKKU");
+
+      mockMvc
+          .perform(
+              put("/api/v1/games/{roomCode}/stage", "AKKU")
+                  .contentType(APPLICATION_JSON)
+                  .content("{\"stageId\":2}"))
+          .andExpect(status().is(status))
+          .andExpect(content().contentTypeCompatibleWith(APPLICATION_JSON))
+          .andExpect(
+              content()
+                  .string(
+                      "{\"error\":\"E"
+                          + code
+                          + " - "
+                          + title
+                          + "\", \"message\":\""
+                          + message
+                          + "\"}"));
+    }
+
+    @Test
+    void changeStageReturnsInternalServerErrorForUnexpectedException() throws Exception {
+      doThrow(new RuntimeException("boom")).when(gameService).changeStage(2, "AKKU");
+
+      mockMvc
+          .perform(
+              put("/api/v1/games/{roomCode}/stage", "AKKU")
+                  .contentType(APPLICATION_JSON)
+                  .content("{\"stageId\":2}"))
+          .andExpect(status().isInternalServerError())
+          .andExpect(content().contentTypeCompatibleWith(APPLICATION_JSON));
+    }
+
+    @Test
+    void changeStageAddsCorsHeaderWhenOriginPresent() throws Exception {
+      mockMvc
+          .perform(
+              put("/api/v1/games/{roomCode}/stage", "AKKU")
+                  .header("Origin", "https://example.com")
+                  .contentType(APPLICATION_JSON)
+                  .content("{\"stageId\":2}"))
+          .andExpect(status().isOk())
+          .andExpect(header().string("Access-Control-Allow-Origin", "*"));
+    }
+
+    static Stream<Arguments> derivedExceptionsForChangeStage() {
+      return Stream.of(
+          Arguments.of(422, "002", "Malformed argument", "stage_id must be between 0 and 3."),
+          Arguments.of(409, "003", "Wrong game-state", "Illegal stage transition."),
+          Arguments.of(503, "004", "App not reachable", "TV app is not reachable."));
+    }
+  }
+
+  @Nested
+  class CreateGameContract {
+
+    @Test
+    void createGameRejectsUnsupportedMethod() throws Exception {
+      mockMvc.perform(get("/api/v1/games")).andExpect(status().isMethodNotAllowed());
+      verifyNoInteractions(gameService);
+    }
+
+    @Test
+    void createGameRejectsUnsupportedMediaType() throws Exception {
+      mockMvc
+          .perform(post("/api/v1/games").contentType("text/plain").content("nope"))
+          .andExpect(status().isUnsupportedMediaType());
+      verifyNoInteractions(gameService);
+    }
+
+    @Test
+    void createGamePreflightReturnsCorsHeaders() throws Exception {
+      mockMvc
+          .perform(
+              options("/api/v1/games")
+                  .header("Origin", "https://example.com")
+                  .header("Access-Control-Request-Method", "POST"))
+          .andExpect(status().isOk())
+          .andExpect(header().string("Access-Control-Allow-Origin", "*"));
+    }
+
+    @Test
+    void createGameMalformedJsonDoesNotCallService() throws Exception {
+      mockMvc
+          .perform(post("/api/v1/games").contentType(APPLICATION_JSON).content("{\"maxSongs\":"))
+          .andExpect(status().isBadRequest());
+
+      verifyNoInteractions(gameService);
+    }
+  }
+
+  @Nested
+  class ChangeStageContract {
+
+    @Test
+    void changeStageRejectsUnsupportedMethod() throws Exception {
+      mockMvc
+          .perform(post("/api/v1/games/{roomCode}/stage", "AKKU"))
+          .andExpect(status().isMethodNotAllowed());
+      verifyNoInteractions(gameService);
+    }
+
+    @Test
+    void changeStageRejectsUnsupportedMediaType() throws Exception {
+      mockMvc
+          .perform(
+              put("/api/v1/games/{roomCode}/stage", "AKKU").contentType("text/plain").content("2"))
+          .andExpect(status().isUnsupportedMediaType());
+      verifyNoInteractions(gameService);
+    }
+
+    @Test
+    void changeStageReturnsEmptyBodyOnSuccess() throws Exception {
+      mockMvc
+          .perform(
+              put("/api/v1/games/{roomCode}/stage", "AKKU")
+                  .contentType(APPLICATION_JSON)
+                  .content("{\"stageId\":2}"))
+          .andExpect(status().isOk())
+          .andExpect(content().string(""));
+    }
+
+    @Test
+    void changeStagePreflightReturnsCorsHeaders() throws Exception {
+      mockMvc
+          .perform(
+              options("/api/v1/games/{roomCode}/stage", "AKKU")
+                  .header("Origin", "https://example.com")
+                  .header("Access-Control-Request-Method", "PUT"))
+          .andExpect(status().isOk())
+          .andExpect(header().string("Access-Control-Allow-Origin", "*"));
+    }
+
+    @Test
+    void changeStageMalformedJsonDoesNotCallService() throws Exception {
+      mockMvc
+          .perform(
+              put("/api/v1/games/{roomCode}/stage", "AKKU")
+                  .contentType(APPLICATION_JSON)
+                  .content("{\"stageId\":"))
+          .andExpect(status().isBadRequest());
+
+      verifyNoInteractions(gameService);
+    }
+  }
+
+  @Nested
+  class CreateGameBinding {
+
+    @Test
+    void createGameRejectsStringForNumericField() throws Exception {
+      mockMvc
+          .perform(
+              post("/api/v1/games")
+                  .contentType(APPLICATION_JSON)
+                  .content("{\"maxSongs\":\"ten\",\"maxAlbums\":3}"))
+          .andExpect(status().isBadRequest());
+
+      verifyNoInteractions(gameService);
+    }
+
+    @Test
+    void createGameAllowsNullMaxSongsAndForwardsIt() throws Exception {
+      when(gameService.createGame(any())).thenReturn("ROOM");
+
+      mockMvc
+          .perform(
+              post("/api/v1/games")
+                  .contentType(APPLICATION_JSON)
+                  .content("{\"maxSongs\":null,\"maxAlbums\":3}"))
+          .andExpect(status().isOk());
+
+      ArgumentCaptor<CreateGameRequest> captor = ArgumentCaptor.forClass(CreateGameRequest.class);
+      verify(gameService).createGame(captor.capture());
+      assertNull(captor.getValue().maxSongs());
+      assertEquals(3, captor.getValue().maxAlbums());
+    }
+
+    @Test
+    void createGameUnknownFieldBehaviorIsDocumented() throws Exception {
+      when(gameService.createGame(any())).thenReturn("ROOM");
+
+      mockMvc
+          .perform(
+              post("/api/v1/games")
+                  .contentType(APPLICATION_JSON)
+                  .content("{\"maxSongs\":10,\"maxAlbums\":3,\"extra\":\"ignored\"}"))
+          .andExpect(status().isOk())
+          .andExpect(content().json("{\"roomCode\":\"ROOM\"}"));
+    }
+  }
+
+  @Nested
+  class ChangeStageBinding {
+
+    @Test
+    void changeStageRejectsStringForStageId() throws Exception {
+      mockMvc
+          .perform(
+              put("/api/v1/games/{roomCode}/stage", "AKKU")
+                  .contentType(APPLICATION_JSON)
+                  .content("{\"stageId\":\"two\"}"))
+          .andExpect(status().isBadRequest());
+
+      verifyNoInteractions(gameService);
+    }
+
+    @Test
+    void changeStageRejectsExplicitNullStageId() throws Exception {
+      mockMvc
+          .perform(
+              put("/api/v1/games/{roomCode}/stage", "AKKU")
+                  .contentType(APPLICATION_JSON)
+                  .content("{\"stageId\":null}"))
+          .andExpect(status().isBadRequest());
+
+      verifyNoInteractions(gameService);
+    }
+
+    @Test
+    void changeStageIgnoresUnknownFieldsWhenMainPayloadIsValid() throws Exception {
+      mockMvc
+          .perform(
+              put("/api/v1/games/{roomCode}/stage", "AKKU")
+                  .contentType(APPLICATION_JSON)
+                  .content("{\"stageId\":2,\"extra\":\"ignored\"}"))
+          .andExpect(status().isOk())
+          .andExpect(content().string(""));
+    }
+  }
+}

--- a/apps/backend/src/test/java/com/cevapinxile/cestereg/api/quiz/controller/InterruptControllerTest.java
+++ b/apps/backend/src/test/java/com/cevapinxile/cestereg/api/quiz/controller/InterruptControllerTest.java
@@ -1,0 +1,777 @@
+package com.cevapinxile.cestereg.api.quiz.controller;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.springframework.http.MediaType.APPLICATION_JSON;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.options;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.cevapinxile.cestereg.api.quiz.dto.request.AnswerRequest;
+import com.cevapinxile.cestereg.api.support.ControllerTestSupport;
+import com.cevapinxile.cestereg.core.service.InterruptService;
+import java.util.UUID;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(InterruptController.class)
+class InterruptControllerTest extends ControllerTestSupport {
+
+  @Autowired private MockMvc mockMvc;
+
+  @MockitoBean private InterruptService interruptService;
+
+  @Nested
+  class InterruptTests {
+
+    @Test
+    void interruptReturnsOkAndForwardsTeamId() throws Exception {
+      UUID teamId = UUID.randomUUID();
+
+      mockMvc
+          .perform(
+              post("/api/v1/games/{roomCode}/interrupts", "AKKU")
+                  .contentType(APPLICATION_JSON)
+                  .content("{\"teamId\":\"" + teamId + "\"}"))
+          .andExpect(status().isOk());
+
+      verify(interruptService).interrupt("AKKU", teamId);
+    }
+
+    @Test
+    void interruptAllowsSystemInterruptByForwardingNullTeamId() throws Exception {
+      mockMvc
+          .perform(
+              post("/api/v1/games/{roomCode}/interrupts", "AKKU")
+                  .contentType(APPLICATION_JSON)
+                  .content("{}"))
+          .andExpect(status().isOk());
+
+      verify(interruptService).interrupt("AKKU", null);
+    }
+
+    @Test
+    void interruptReturnsBadRequestForMissingBody() throws Exception {
+      mockMvc
+          .perform(post("/api/v1/games/{roomCode}/interrupts", "AKKU"))
+          .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void interruptDoesNotValidateRoomCodeFormatAtControllerLevel() throws Exception {
+      mockMvc
+          .perform(
+              post("/api/v1/games/{roomCode}/interrupts", "abc")
+                  .contentType(APPLICATION_JSON)
+                  .content("{}"))
+          .andExpect(status().isOk());
+
+      verify(interruptService).interrupt("abc", null);
+    }
+
+    @ParameterizedTest
+    @MethodSource("derivedExceptionsForInterrupt")
+    void interruptMapsDerivedExceptions(int status, String code, String title, String message)
+        throws Exception {
+      doThrow(derived(status, code, title, message)).when(interruptService).interrupt("AKKU", null);
+
+      mockMvc
+          .perform(
+              post("/api/v1/games/{roomCode}/interrupts", "AKKU")
+                  .contentType(APPLICATION_JSON)
+                  .content("{}"))
+          .andExpect(status().is(status))
+          .andExpect(content().contentTypeCompatibleWith(APPLICATION_JSON))
+          .andExpect(
+              content()
+                  .string(
+                      "{\"error\":\"E"
+                          + code
+                          + " - "
+                          + title
+                          + "\", \"message\":\""
+                          + message
+                          + "\"}"));
+    }
+
+    @Test
+    void interruptReturnsInternalServerErrorForUnexpectedException() throws Exception {
+      doThrow(new RuntimeException("boom")).when(interruptService).interrupt("AKKU", null);
+
+      mockMvc
+          .perform(
+              post("/api/v1/games/{roomCode}/interrupts", "AKKU")
+                  .contentType(APPLICATION_JSON)
+                  .content("{}"))
+          .andExpect(status().isInternalServerError())
+          .andExpect(content().contentTypeCompatibleWith(APPLICATION_JSON));
+    }
+
+    @Test
+    void interruptAddsCorsHeaderWhenOriginPresent() throws Exception {
+      mockMvc
+          .perform(
+              post("/api/v1/games/{roomCode}/interrupts", "AKKU")
+                  .header("Origin", "https://example.com")
+                  .contentType(APPLICATION_JSON)
+                  .content("{}"))
+          .andExpect(status().isOk())
+          .andExpect(header().string("Access-Control-Allow-Origin", "*"));
+    }
+
+    static Stream<Arguments> derivedExceptionsForInterrupt() {
+      return Stream.of(
+          Arguments.of(404, "001", "Invalid referenced object", "Game or team not found."),
+          Arguments.of(409, "006", "Guess wasn't allowed", "Interrupt rejected."),
+          Arguments.of(401, "005", "Unauthorized request", "Team does not belong to game."));
+    }
+  }
+
+  @Nested
+  class ResolveErrorsTests {
+
+    @Test
+    void resolveErrorsReturnsOkAndForwardsScheduleId() throws Exception {
+      UUID scheduleId = UUID.randomUUID();
+
+      mockMvc
+          .perform(
+              post("/api/v1/games/{roomCode}/interrupts/system/resolve", "AKKU")
+                  .contentType(APPLICATION_JSON)
+                  .content("{\"scheduleId\":\"" + scheduleId + "\"}"))
+          .andExpect(status().isOk());
+
+      verify(interruptService).resolveErrors(scheduleId, "AKKU");
+    }
+
+    @Test
+    void resolveErrorsReturnsBadRequestForMissingBody() throws Exception {
+      mockMvc
+          .perform(post("/api/v1/games/{roomCode}/interrupts/system/resolve", "AKKU"))
+          .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void resolveErrorsForwardsNullScheduleIdWhenPayloadOmitsIt() throws Exception {
+      mockMvc
+          .perform(
+              post("/api/v1/games/{roomCode}/interrupts/system/resolve", "AKKU")
+                  .contentType(APPLICATION_JSON)
+                  .content("{}"))
+          .andExpect(status().isOk());
+
+      verify(interruptService).resolveErrors(null, "AKKU");
+    }
+
+    @ParameterizedTest
+    @MethodSource("derivedExceptionsForResolveErrors")
+    void resolveErrorsMapsDerivedExceptions(int status, String code, String title, String message)
+        throws Exception {
+      doThrow(derived(status, code, title, message))
+          .when(interruptService)
+          .resolveErrors(null, "AKKU");
+
+      mockMvc
+          .perform(
+              post("/api/v1/games/{roomCode}/interrupts/system/resolve", "AKKU")
+                  .contentType(APPLICATION_JSON)
+                  .content("{}"))
+          .andExpect(status().is(status))
+          .andExpect(content().contentTypeCompatibleWith(APPLICATION_JSON))
+          .andExpect(
+              content()
+                  .string(
+                      "{\"error\":\"E"
+                          + code
+                          + " - "
+                          + title
+                          + "\", \"message\":\""
+                          + message
+                          + "\"}"));
+    }
+
+    @Test
+    void resolveErrorsReturnsInternalServerErrorForUnexpectedException() throws Exception {
+      doThrow(new RuntimeException("boom")).when(interruptService).resolveErrors(null, "AKKU");
+
+      mockMvc
+          .perform(
+              post("/api/v1/games/{roomCode}/interrupts/system/resolve", "AKKU")
+                  .contentType(APPLICATION_JSON)
+                  .content("{}"))
+          .andExpect(status().isInternalServerError())
+          .andExpect(content().contentTypeCompatibleWith(APPLICATION_JSON));
+    }
+
+    @Test
+    void resolveErrorsAddsCorsHeaderWhenOriginPresent() throws Exception {
+      mockMvc
+          .perform(
+              post("/api/v1/games/{roomCode}/interrupts/system/resolve", "AKKU")
+                  .header("Origin", "https://example.com")
+                  .contentType(APPLICATION_JSON)
+                  .content("{}"))
+          .andExpect(status().isOk())
+          .andExpect(header().string("Access-Control-Allow-Origin", "*"));
+    }
+
+    static Stream<Arguments> derivedExceptionsForResolveErrors() {
+      return Stream.of(
+          Arguments.of(404, "001", "Invalid referenced object", "Game or schedule not found."),
+          Arguments.of(409, "003", "Wrong game-state", "Allowed only in stage 2."),
+          Arguments.of(
+              503, "004", "App not reachable", "Cannot resume because an app is missing."));
+    }
+  }
+
+  @Nested
+  class AnswerTests {
+
+    @Test
+    void answerReturnsOkAndForwardsAnswerRequest() throws Exception {
+      UUID answerId = UUID.randomUUID();
+
+      mockMvc
+          .perform(
+              post("/api/v1/games/{roomCode}/interrupts/{answerId}/answer", "AKKU", answerId)
+                  .contentType(APPLICATION_JSON)
+                  .content("{\"correct\":true}"))
+          .andExpect(status().isOk());
+
+      ArgumentCaptor<AnswerRequest> captor = ArgumentCaptor.forClass(AnswerRequest.class);
+      verify(interruptService).answer(eq(answerId), captor.capture(), eq("AKKU"));
+      assertTrue(captor.getValue().correct());
+    }
+
+    @Test
+    void answerReturnsBadRequestForMissingBody() throws Exception {
+      mockMvc
+          .perform(
+              post(
+                  "/api/v1/games/{roomCode}/interrupts/{answerId}/answer",
+                  "AKKU",
+                  UUID.randomUUID()))
+          .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void answerReturnsBadRequestWhenCorrectFlagMissingFromPayload() throws Exception {
+      mockMvc
+          .perform(
+              post(
+                      "/api/v1/games/{roomCode}/interrupts/{answerId}/answer",
+                      "AKKU",
+                      UUID.randomUUID())
+                  .contentType(APPLICATION_JSON)
+                  .content("{}"))
+          .andExpect(status().isBadRequest());
+
+      verifyNoInteractions(interruptService);
+    }
+
+    @ParameterizedTest
+    @MethodSource("derivedExceptionsForAnswer")
+    void answerMapsDerivedExceptions(int status, String code, String title, String message)
+        throws Exception {
+      UUID answerId = UUID.randomUUID();
+      doThrow(derived(status, code, title, message))
+          .when(interruptService)
+          .answer(eq(answerId), any(), eq("AKKU"));
+
+      mockMvc
+          .perform(
+              post("/api/v1/games/{roomCode}/interrupts/{answerId}/answer", "AKKU", answerId)
+                  .contentType(APPLICATION_JSON)
+                  .content("{\"correct\":false}"))
+          .andExpect(status().is(status))
+          .andExpect(content().contentTypeCompatibleWith(APPLICATION_JSON))
+          .andExpect(
+              content()
+                  .string(
+                      "{\"error\":\"E"
+                          + code
+                          + " - "
+                          + title
+                          + "\", \"message\":\""
+                          + message
+                          + "\"}"));
+    }
+
+    @Test
+    void answerReturnsInternalServerErrorForUnexpectedException() throws Exception {
+      UUID answerId = UUID.randomUUID();
+      doThrow(new RuntimeException("boom"))
+          .when(interruptService)
+          .answer(eq(answerId), any(), eq("AKKU"));
+
+      mockMvc
+          .perform(
+              post("/api/v1/games/{roomCode}/interrupts/{answerId}/answer", "AKKU", answerId)
+                  .contentType(APPLICATION_JSON)
+                  .content("{\"correct\":true}"))
+          .andExpect(status().isInternalServerError())
+          .andExpect(content().contentTypeCompatibleWith(APPLICATION_JSON));
+    }
+
+    @Test
+    void answerAddsCorsHeaderWhenOriginPresent() throws Exception {
+      UUID answerId = UUID.randomUUID();
+
+      mockMvc
+          .perform(
+              post("/api/v1/games/{roomCode}/interrupts/{answerId}/answer", "AKKU", answerId)
+                  .header("Origin", "https://example.com")
+                  .contentType(APPLICATION_JSON)
+                  .content("{\"correct\":true}"))
+          .andExpect(status().isOk())
+          .andExpect(header().string("Access-Control-Allow-Origin", "*"));
+    }
+
+    static Stream<Arguments> derivedExceptionsForAnswer() {
+      return Stream.of(
+          Arguments.of(404, "001", "Invalid referenced object", "Game or interrupt not found."),
+          Arguments.of(
+              422, "002", "Malformed argument", "Interrupt does not belong to the specified game."),
+          Arguments.of(
+              409,
+              "003",
+              "Wrong game-state",
+              "Answering allowed only for unresolved stage-2 interrupts."),
+          Arguments.of(503, "004", "App not reachable", "An app is missing."));
+    }
+  }
+
+  @Nested
+  class SavePreviousScenarioTests {
+
+    @Test
+    void savePreviousScenarioReturnsOkAndForwardsScenario() throws Exception {
+      mockMvc
+          .perform(
+              put("/api/v1/games/{roomCode}/ui/scenario", "AKKU")
+                  .contentType(APPLICATION_JSON)
+                  .content("{\"scenario\":2}"))
+          .andExpect(status().isOk());
+
+      verify(interruptService).savePreviousScenario(2, "AKKU");
+    }
+
+    @Test
+    void savePreviousScenarioReturnsBadRequestForMissingBody() throws Exception {
+      mockMvc
+          .perform(put("/api/v1/games/{roomCode}/ui/scenario", "AKKU"))
+          .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void savePreviousScenarioReturnsBadRequestWhenScenarioMissingFromPayload() throws Exception {
+      mockMvc
+          .perform(
+              put("/api/v1/games/{roomCode}/ui/scenario", "AKKU")
+                  .contentType(APPLICATION_JSON)
+                  .content("{}"))
+          .andExpect(status().isBadRequest());
+
+      verifyNoInteractions(interruptService);
+    }
+
+    @ParameterizedTest
+    @MethodSource("derivedExceptionsForSavePreviousScenario")
+    void savePreviousScenarioMapsDerivedExceptions(
+        int status, String code, String title, String message) throws Exception {
+      doThrow(derived(status, code, title, message))
+          .when(interruptService)
+          .savePreviousScenario(2, "AKKU");
+
+      mockMvc
+          .perform(
+              put("/api/v1/games/{roomCode}/ui/scenario", "AKKU")
+                  .contentType(APPLICATION_JSON)
+                  .content("{\"scenario\":2}"))
+          .andExpect(status().is(status))
+          .andExpect(content().contentTypeCompatibleWith(APPLICATION_JSON))
+          .andExpect(
+              content()
+                  .string(
+                      "{\"error\":\"E"
+                          + code
+                          + " - "
+                          + title
+                          + "\", \"message\":\""
+                          + message
+                          + "\"}"));
+    }
+
+    @Test
+    void savePreviousScenarioReturnsInternalServerErrorForUnexpectedException() throws Exception {
+      doThrow(new RuntimeException("boom")).when(interruptService).savePreviousScenario(2, "AKKU");
+
+      mockMvc
+          .perform(
+              put("/api/v1/games/{roomCode}/ui/scenario", "AKKU")
+                  .contentType(APPLICATION_JSON)
+                  .content("{\"scenario\":2}"))
+          .andExpect(status().isInternalServerError())
+          .andExpect(content().contentTypeCompatibleWith(APPLICATION_JSON));
+    }
+
+    @Test
+    void savePreviousScenarioAddsCorsHeaderWhenOriginPresent() throws Exception {
+      mockMvc
+          .perform(
+              put("/api/v1/games/{roomCode}/ui/scenario", "AKKU")
+                  .header("Origin", "https://example.com")
+                  .contentType(APPLICATION_JSON)
+                  .content("{\"scenario\":2}"))
+          .andExpect(status().isOk())
+          .andExpect(header().string("Access-Control-Allow-Origin", "*"));
+    }
+
+    static Stream<Arguments> derivedExceptionsForSavePreviousScenario() {
+      return Stream.of(
+          Arguments.of(404, "001", "Invalid referenced object", "Game not found."),
+          Arguments.of(
+              422, "002", "Malformed argument", "scenario must be 0..4 and must not be 3."),
+          Arguments.of(409, "003", "Wrong game-state", "Saving scenario allowed only in stage 2."));
+    }
+  }
+
+  @Nested
+  class InterruptContract {
+
+    @Test
+    void interruptRejectsUnsupportedMethod() throws Exception {
+      mockMvc
+          .perform(delete("/api/v1/games/{roomCode}/interrupts", "AKKU"))
+          .andExpect(status().isMethodNotAllowed())
+          .andDo(
+              result -> {
+                System.out.println("Mastika");
+                System.out.println("status = " + result.getResponse().getStatus());
+                System.out.println(
+                    "handler = " + result.getResponse().getHeader("X-Exception-Handler"));
+                System.out.println("body = " + result.getResponse().getContentAsString());
+                System.out.println("resolved = " + result.getResolvedException());
+              });
+      verifyNoInteractions(interruptService);
+    }
+
+    @Test
+    void interruptRejectsUnsupportedMediaType() throws Exception {
+      mockMvc
+          .perform(
+              post("/api/v1/games/{roomCode}/interrupts", "AKKU")
+                  .contentType("text/plain")
+                  .content("x"))
+          .andExpect(status().isUnsupportedMediaType());
+      verifyNoInteractions(interruptService);
+    }
+
+    @Test
+    void interruptMalformedJsonDoesNotCallService() throws Exception {
+      mockMvc
+          .perform(
+              post("/api/v1/games/{roomCode}/interrupts", "AKKU")
+                  .contentType(APPLICATION_JSON)
+                  .content("{\"teamId\":"))
+          .andExpect(status().isBadRequest());
+      verifyNoInteractions(interruptService);
+    }
+
+    @Test
+    void interruptPreflightReturnsCorsHeaders() throws Exception {
+      mockMvc
+          .perform(
+              options("/api/v1/games/{roomCode}/interrupts", "AKKU")
+                  .header("Origin", "https://example.com")
+                  .header("Access-Control-Request-Method", "POST"))
+          .andExpect(status().isOk())
+          .andExpect(header().string("Access-Control-Allow-Origin", "*"));
+    }
+  }
+
+  @Nested
+  class ResolveErrorsContract {
+
+    @Test
+    void resolveErrorsRejectsUnsupportedMethod() throws Exception {
+      mockMvc
+          .perform(put("/api/v1/games/{roomCode}/interrupts/system/resolve", "AKKU"))
+          .andExpect(status().isMethodNotAllowed());
+      verifyNoInteractions(interruptService);
+    }
+
+    @Test
+    void resolveErrorsRejectsUnsupportedMediaType() throws Exception {
+      mockMvc
+          .perform(
+              post("/api/v1/games/{roomCode}/interrupts/system/resolve", "AKKU")
+                  .contentType("text/plain")
+                  .content("x"))
+          .andExpect(status().isUnsupportedMediaType());
+      verifyNoInteractions(interruptService);
+    }
+
+    @Test
+    void resolveErrorsMalformedJsonDoesNotCallService() throws Exception {
+      mockMvc
+          .perform(
+              post("/api/v1/games/{roomCode}/interrupts/system/resolve", "AKKU")
+                  .contentType(APPLICATION_JSON)
+                  .content("{\"scheduleId\":"))
+          .andExpect(status().isBadRequest());
+      verifyNoInteractions(interruptService);
+    }
+  }
+
+  @Nested
+  class AnswerContract {
+
+    @Test
+    void answerRejectsUnsupportedMethod() throws Exception {
+      mockMvc
+          .perform(
+              put(
+                  "/api/v1/games/{roomCode}/interrupts/{answerId}/answer",
+                  "AKKU",
+                  UUID.randomUUID()))
+          .andExpect(status().isMethodNotAllowed());
+      verifyNoInteractions(interruptService);
+    }
+
+    @Test
+    void answerRejectsUnsupportedMediaType() throws Exception {
+      mockMvc
+          .perform(
+              post(
+                      "/api/v1/games/{roomCode}/interrupts/{answerId}/answer",
+                      "AKKU",
+                      UUID.randomUUID())
+                  .contentType("text/plain")
+                  .content("x"))
+          .andExpect(status().isUnsupportedMediaType());
+      verifyNoInteractions(interruptService);
+    }
+
+    @Test
+    void answerMalformedJsonDoesNotCallService() throws Exception {
+      mockMvc
+          .perform(
+              post(
+                      "/api/v1/games/{roomCode}/interrupts/{answerId}/answer",
+                      "AKKU",
+                      UUID.randomUUID())
+                  .contentType(APPLICATION_JSON)
+                  .content("{\"correct\":"))
+          .andExpect(status().isBadRequest());
+      verifyNoInteractions(interruptService);
+    }
+
+    @Test
+    void malformedAnswerIdDoesNotCallService() throws Exception {
+      mockMvc
+          .perform(
+              post("/api/v1/games/{roomCode}/interrupts/{answerId}/answer", "AKKU", "not-a-uuid")
+                  .contentType(APPLICATION_JSON)
+                  .content("{\"correct\":true}"))
+          .andExpect(status().isBadRequest());
+      verifyNoInteractions(interruptService);
+    }
+  }
+
+  @Nested
+  class SaveScenarioContract {
+
+    @Test
+    void saveScenarioRejectsUnsupportedMethod() throws Exception {
+      mockMvc
+          .perform(
+              post("/api/v1/games/{roomCode}/ui/scenario", "AKKU")
+                  .contentType(APPLICATION_JSON)
+                  .content("{\"scenario\":2}"))
+          .andExpect(status().isMethodNotAllowed());
+      verifyNoInteractions(interruptService);
+    }
+
+    @Test
+    void saveScenarioRejectsUnsupportedMediaType() throws Exception {
+      mockMvc
+          .perform(
+              put("/api/v1/games/{roomCode}/ui/scenario", "AKKU")
+                  .contentType("text/plain")
+                  .content("2"))
+          .andExpect(status().isUnsupportedMediaType());
+      verifyNoInteractions(interruptService);
+    }
+
+    @Test
+    void saveScenarioMalformedJsonDoesNotCallService() throws Exception {
+      mockMvc
+          .perform(
+              put("/api/v1/games/{roomCode}/ui/scenario", "AKKU")
+                  .contentType(APPLICATION_JSON)
+                  .content("{\"scenario\":"))
+          .andExpect(status().isBadRequest());
+      verifyNoInteractions(interruptService);
+    }
+  }
+
+  @Nested
+  class InterruptBinding {
+
+    @Test
+    void interruptRejectsNumericTeamIdIfEndpointRequiresUuidOrStringShape() throws Exception {
+      mockMvc
+          .perform(
+              post("/api/v1/games/{roomCode}/interrupts", "AKKU")
+                  .contentType(APPLICATION_JSON)
+                  .content("{\"teamId\":123}"))
+          .andExpect(status().isBadRequest());
+
+      verifyNoInteractions(interruptService);
+    }
+
+    @Test
+    void interruptAllowsExplicitNullTeamIdAndForwardsIt() throws Exception {
+      mockMvc
+          .perform(
+              post("/api/v1/games/{roomCode}/interrupts", "AKKU")
+                  .contentType(APPLICATION_JSON)
+                  .content("{\"teamId\":null}"))
+          .andExpect(status().isOk());
+
+      Mockito.verify(interruptService).interrupt("AKKU", null);
+    }
+  }
+
+  @Nested
+  class ResolveBinding {
+
+    @Test
+    void resolveErrorsRejectsWrongJsonTypeForScheduleId() throws Exception {
+      mockMvc
+          .perform(
+              post("/api/v1/games/{roomCode}/interrupts/system/resolve", "AKKU")
+                  .contentType(APPLICATION_JSON)
+                  .content("{\"scheduleId\":123}"))
+          .andExpect(status().isBadRequest());
+
+      verifyNoInteractions(interruptService);
+    }
+
+    @Test
+    void resolveErrorsAllowsExplicitNullScheduleIdAndForwardsIt() throws Exception {
+      mockMvc
+          .perform(
+              post("/api/v1/games/{roomCode}/interrupts/system/resolve", "AKKU")
+                  .contentType(APPLICATION_JSON)
+                  .content("{\"scheduleId\":null}"))
+          .andExpect(status().isOk());
+
+      Mockito.verify(interruptService).resolveErrors(null, "AKKU");
+    }
+  }
+
+  @Nested
+  class AnswerBinding {
+
+    @Test
+    void answerRejectsStringForBooleanField() throws Exception {
+      mockMvc
+          .perform(
+              post(
+                      "/api/v1/games/{roomCode}/interrupts/{answerId}/answer",
+                      "AKKU",
+                      UUID.randomUUID())
+                  .contentType(APPLICATION_JSON)
+                  .content("{\"correct\":\"yes\"}"))
+          .andExpect(status().isBadRequest());
+
+      verifyNoInteractions(interruptService);
+    }
+
+    @Test
+    void answerRejectsExplicitNullBooleanField() throws Exception {
+      mockMvc
+          .perform(
+              post(
+                      "/api/v1/games/{roomCode}/interrupts/{answerId}/answer",
+                      "AKKU",
+                      UUID.randomUUID())
+                  .contentType(APPLICATION_JSON)
+                  .content("{\"correct\":null}"))
+          .andExpect(status().isBadRequest());
+
+      verifyNoInteractions(interruptService);
+    }
+
+    @Test
+    void answerIgnoresUnknownFieldsWhenMainPayloadIsValid() throws Exception {
+      mockMvc
+          .perform(
+              post(
+                      "/api/v1/games/{roomCode}/interrupts/{answerId}/answer",
+                      "AKKU",
+                      UUID.randomUUID())
+                  .contentType(APPLICATION_JSON)
+                  .content("{\"correct\":true,\"extra\":\"ignored\"}"))
+          .andExpect(status().isOk());
+    }
+  }
+
+  @Nested
+  class ScenarioBinding {
+
+    @Test
+    void savePreviousScenarioRejectsStringForNumericField() throws Exception {
+      mockMvc
+          .perform(
+              put("/api/v1/games/{roomCode}/ui/scenario", "AKKU")
+                  .contentType(APPLICATION_JSON)
+                  .content("{\"scenario\":\"two\"}"))
+          .andExpect(status().isBadRequest());
+
+      verifyNoInteractions(interruptService);
+    }
+
+    @Test
+    void savePreviousScenarioRejectsExplicitNullScenario() throws Exception {
+      mockMvc
+          .perform(
+              put("/api/v1/games/{roomCode}/ui/scenario", "AKKU")
+                  .contentType(APPLICATION_JSON)
+                  .content("{\"scenario\":null}"))
+          .andExpect(status().isBadRequest());
+
+      verifyNoInteractions(interruptService);
+    }
+
+    @Test
+    void savePreviousScenarioIgnoresUnknownFieldsWhenMainPayloadIsValid() throws Exception {
+      mockMvc
+          .perform(
+              put("/api/v1/games/{roomCode}/ui/scenario", "AKKU")
+                  .contentType(APPLICATION_JSON)
+                  .content("{\"scenario\":2,\"extra\":\"ignored\"}"))
+          .andExpect(status().isOk());
+    }
+  }
+}

--- a/apps/backend/src/test/java/com/cevapinxile/cestereg/api/quiz/controller/ScheduleControllerTest.java
+++ b/apps/backend/src/test/java/com/cevapinxile/cestereg/api/quiz/controller/ScheduleControllerTest.java
@@ -1,0 +1,369 @@
+package com.cevapinxile.cestereg.api.quiz.controller;
+
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.springframework.http.MediaType.APPLICATION_JSON;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.options;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.cevapinxile.cestereg.api.support.ControllerTestSupport;
+import com.cevapinxile.cestereg.core.service.ScheduleService;
+import java.util.UUID;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(ScheduleController.class)
+class ScheduleControllerTest extends ControllerTestSupport {
+
+  @Autowired private MockMvc mockMvc;
+
+  @MockitoBean private ScheduleService scheduleService;
+
+  @Nested
+  class ReplaySongTests {
+
+    @Test
+    void replaySongReturnsOk() throws Exception {
+      UUID scheduleId = UUID.randomUUID();
+
+      mockMvc
+          .perform(
+              post("/api/v1/games/{roomCode}/schedules/{scheduleId}/replay", "AKKU", scheduleId))
+          .andExpect(status().isOk())
+          .andExpect(content().string(""));
+
+      verify(scheduleService).replaySong(scheduleId, "AKKU");
+    }
+
+    @Test
+    void replaySongDoesNotValidateRoomCodeFormatAtControllerLevel() throws Exception {
+      UUID scheduleId = UUID.randomUUID();
+
+      mockMvc
+          .perform(
+              post("/api/v1/games/{roomCode}/schedules/{scheduleId}/replay", "abc", scheduleId))
+          .andExpect(status().isOk());
+
+      verify(scheduleService).replaySong(scheduleId, "abc");
+    }
+
+    @ParameterizedTest
+    @MethodSource("derivedExceptionsForReplaySong")
+    void replaySongMapsDerivedExceptions(int status, String code, String title, String message)
+        throws Exception {
+      UUID scheduleId = UUID.randomUUID();
+      doThrow(derived(status, code, title, message))
+          .when(scheduleService)
+          .replaySong(scheduleId, "AKKU");
+
+      mockMvc
+          .perform(
+              post("/api/v1/games/{roomCode}/schedules/{scheduleId}/replay", "AKKU", scheduleId))
+          .andExpect(status().is(status))
+          .andExpect(content().contentTypeCompatibleWith(APPLICATION_JSON))
+          .andExpect(
+              content()
+                  .string(
+                      "{\"error\":\"E"
+                          + code
+                          + " - "
+                          + title
+                          + "\", \"message\":\""
+                          + message
+                          + "\"}"));
+    }
+
+    @Test
+    void replaySongReturnsInternalServerErrorForUnexpectedException() throws Exception {
+      UUID scheduleId = UUID.randomUUID();
+      doThrow(new RuntimeException("boom")).when(scheduleService).replaySong(scheduleId, "AKKU");
+
+      mockMvc
+          .perform(
+              post("/api/v1/games/{roomCode}/schedules/{scheduleId}/replay", "AKKU", scheduleId))
+          .andExpect(status().isInternalServerError())
+          .andExpect(content().contentTypeCompatibleWith(APPLICATION_JSON));
+    }
+
+    @Test
+    void replaySongAddsCorsHeaderWhenOriginPresent() throws Exception {
+      UUID scheduleId = UUID.randomUUID();
+
+      mockMvc
+          .perform(
+              post("/api/v1/games/{roomCode}/schedules/{scheduleId}/replay", "AKKU", scheduleId)
+                  .header("Origin", "https://example.com"))
+          .andExpect(status().isOk())
+          .andExpect(header().string("Access-Control-Allow-Origin", "*"));
+    }
+
+    static Stream<Arguments> derivedExceptionsForReplaySong() {
+      return Stream.of(
+          Arguments.of(404, "001", "Invalid referenced object", "Game or schedule not found."),
+          Arguments.of(409, "003", "Wrong game-state", "Replay allowed only in stage 2."),
+          Arguments.of(503, "004", "App not reachable", "An app is missing."));
+    }
+  }
+
+  @Nested
+  class RevealAnswerTests {
+
+    @Test
+    void revealAnswerReturnsOk() throws Exception {
+      UUID scheduleId = UUID.randomUUID();
+
+      mockMvc
+          .perform(
+              post("/api/v1/games/{roomCode}/schedules/{scheduleId}/reveal", "AKKU", scheduleId))
+          .andExpect(status().isOk());
+
+      verify(scheduleService).revealAnswer(scheduleId, "AKKU");
+    }
+
+    @Test
+    void revealAnswerReturnsBadRequestForMalformedScheduleUuid() throws Exception {
+      mockMvc
+          .perform(
+              post("/api/v1/games/{roomCode}/schedules/{scheduleId}/reveal", "AKKU", "not-a-uuid"))
+          .andExpect(status().isBadRequest());
+    }
+
+    @ParameterizedTest
+    @MethodSource("derivedExceptionsForRevealAnswer")
+    void revealAnswerMapsDerivedExceptions(int status, String code, String title, String message)
+        throws Exception {
+      UUID scheduleId = UUID.randomUUID();
+      doThrow(derived(status, code, title, message))
+          .when(scheduleService)
+          .revealAnswer(scheduleId, "AKKU");
+
+      mockMvc
+          .perform(
+              post("/api/v1/games/{roomCode}/schedules/{scheduleId}/reveal", "AKKU", scheduleId))
+          .andExpect(status().is(status))
+          .andExpect(content().contentTypeCompatibleWith(APPLICATION_JSON))
+          .andExpect(
+              content()
+                  .string(
+                      "{\"error\":\"E"
+                          + code
+                          + " - "
+                          + title
+                          + "\", \"message\":\""
+                          + message
+                          + "\"}"));
+    }
+
+    @Test
+    void revealAnswerReturnsInternalServerErrorForUnexpectedException() throws Exception {
+      UUID scheduleId = UUID.randomUUID();
+      doThrow(new RuntimeException("boom")).when(scheduleService).revealAnswer(scheduleId, "AKKU");
+
+      mockMvc
+          .perform(
+              post("/api/v1/games/{roomCode}/schedules/{scheduleId}/reveal", "AKKU", scheduleId))
+          .andExpect(status().isInternalServerError())
+          .andExpect(content().contentTypeCompatibleWith(APPLICATION_JSON));
+    }
+
+    @Test
+    void revealAnswerAddsCorsHeaderWhenOriginPresent() throws Exception {
+      UUID scheduleId = UUID.randomUUID();
+
+      mockMvc
+          .perform(
+              post("/api/v1/games/{roomCode}/schedules/{scheduleId}/reveal", "AKKU", scheduleId)
+                  .header("Origin", "https://example.com"))
+          .andExpect(status().isOk())
+          .andExpect(header().string("Access-Control-Allow-Origin", "*"));
+    }
+
+    static Stream<Arguments> derivedExceptionsForRevealAnswer() {
+      return Stream.of(
+          Arguments.of(404, "001", "Invalid referenced object", "Game or schedule not found."),
+          Arguments.of(409, "003", "Wrong game-state", "Reveal allowed only in stage 2."),
+          Arguments.of(503, "004", "App not reachable", "An app is missing."));
+    }
+  }
+
+  @Nested
+  class NextTests {
+
+    @Test
+    void nextReturnsOk() throws Exception {
+      mockMvc
+          .perform(post("/api/v1/games/{roomCode}/schedules/next", "AKKU"))
+          .andExpect(status().isOk());
+
+      verify(scheduleService).progress("AKKU");
+    }
+
+    @Test
+    void nextDoesNotValidateRoomCodeFormatAtControllerLevel() throws Exception {
+      mockMvc
+          .perform(post("/api/v1/games/{roomCode}/schedules/next", "abc"))
+          .andExpect(status().isOk());
+
+      verify(scheduleService).progress("abc");
+    }
+
+    @ParameterizedTest
+    @MethodSource("derivedExceptionsForNext")
+    void nextMapsDerivedExceptions(int status, String code, String title, String message)
+        throws Exception {
+      doThrow(derived(status, code, title, message)).when(scheduleService).progress("AKKU");
+
+      mockMvc
+          .perform(post("/api/v1/games/{roomCode}/schedules/next", "AKKU"))
+          .andExpect(status().is(status))
+          .andExpect(content().contentTypeCompatibleWith(APPLICATION_JSON))
+          .andExpect(
+              content()
+                  .string(
+                      "{\"error\":\"E"
+                          + code
+                          + " - "
+                          + title
+                          + "\", \"message\":\""
+                          + message
+                          + "\"}"));
+    }
+
+    @Test
+    void nextReturnsInternalServerErrorForUnexpectedException() throws Exception {
+      doThrow(new RuntimeException("boom")).when(scheduleService).progress("AKKU");
+
+      mockMvc
+          .perform(post("/api/v1/games/{roomCode}/schedules/next", "AKKU"))
+          .andExpect(status().isInternalServerError())
+          .andExpect(content().contentTypeCompatibleWith(APPLICATION_JSON));
+    }
+
+    @Test
+    void nextAddsCorsHeaderWhenOriginPresent() throws Exception {
+      mockMvc
+          .perform(
+              post("/api/v1/games/{roomCode}/schedules/next", "AKKU")
+                  .header("Origin", "https://example.com"))
+          .andExpect(status().isOk())
+          .andExpect(header().string("Access-Control-Allow-Origin", "*"));
+    }
+
+    static Stream<Arguments> derivedExceptionsForNext() {
+      return Stream.of(
+          Arguments.of(404, "001", "Invalid referenced object", "Game not found."),
+          Arguments.of(409, "003", "Wrong game-state", "Next allowed only in stage 2."),
+          Arguments.of(503, "004", "App not reachable", "An app is missing."));
+    }
+  }
+
+  @Nested
+  class ReplayContract {
+    @Test
+    void replayRejectsUnsupportedMethod() throws Exception {
+      mockMvc
+          .perform(
+              delete(
+                  "/api/v1/games/{roomCode}/schedules/{scheduleId}/replay",
+                  "AKKU",
+                  UUID.randomUUID()))
+          .andExpect(status().isMethodNotAllowed());
+      verifyNoInteractions(scheduleService);
+    }
+
+    @Test
+    void replayPreflightReturnsCorsHeaders() throws Exception {
+      mockMvc
+          .perform(
+              options(
+                      "/api/v1/games/{roomCode}/schedules/{scheduleId}/replay",
+                      "AKKU",
+                      UUID.randomUUID())
+                  .header("Origin", "https://example.com")
+                  .header("Access-Control-Request-Method", "POST"))
+          .andExpect(status().isOk())
+          .andExpect(header().string("Access-Control-Allow-Origin", "*"));
+    }
+
+    @Test
+    void malformedScheduleIdDoesNotCallReplayService() throws Exception {
+      mockMvc
+          .perform(
+              post("/api/v1/games/{roomCode}/schedules/{scheduleId}/replay", "AKKU", "not-a-uuid"))
+          .andExpect(status().isBadRequest());
+      verifyNoInteractions(scheduleService);
+    }
+  }
+
+  @Nested
+  class RevealContract {
+    @Test
+    void revealRejectsUnsupportedMethod() throws Exception {
+      mockMvc
+          .perform(
+              delete(
+                  "/api/v1/games/{roomCode}/schedules/{scheduleId}/reveal",
+                  "AKKU",
+                  UUID.randomUUID()))
+          .andExpect(status().isMethodNotAllowed());
+      verifyNoInteractions(scheduleService);
+    }
+
+    @Test
+    void revealPreflightReturnsCorsHeaders() throws Exception {
+      mockMvc
+          .perform(
+              options(
+                      "/api/v1/games/{roomCode}/schedules/{scheduleId}/reveal",
+                      "AKKU",
+                      UUID.randomUUID())
+                  .header("Origin", "https://example.com")
+                  .header("Access-Control-Request-Method", "POST"))
+          .andExpect(status().isOk())
+          .andExpect(header().string("Access-Control-Allow-Origin", "*"));
+    }
+  }
+
+  @Nested
+  class NextContract {
+    @Test
+    void nextRejectsUnsupportedMethod() throws Exception {
+      mockMvc
+          .perform(delete("/api/v1/games/{roomCode}/schedules/next", "AKKU"))
+          .andExpect(status().isMethodNotAllowed());
+      verifyNoInteractions(scheduleService);
+    }
+
+    @Test
+    void nextReturnsEmptyBodyOnSuccess() throws Exception {
+      mockMvc
+          .perform(post("/api/v1/games/{roomCode}/schedules/next", "AKKU"))
+          .andExpect(status().isOk())
+          .andExpect(content().string(""));
+    }
+
+    @Test
+    void nextPreflightReturnsCorsHeaders() throws Exception {
+      mockMvc
+          .perform(
+              options("/api/v1/games/{roomCode}/schedules/next", "AKKU")
+                  .header("Origin", "https://example.com")
+                  .header("Access-Control-Request-Method", "POST"))
+          .andExpect(status().isOk())
+          .andExpect(header().string("Access-Control-Allow-Origin", "*"));
+    }
+  }
+}

--- a/apps/backend/src/test/java/com/cevapinxile/cestereg/api/quiz/controller/TeamControllerTest.java
+++ b/apps/backend/src/test/java/com/cevapinxile/cestereg/api/quiz/controller/TeamControllerTest.java
@@ -1,0 +1,391 @@
+package com.cevapinxile.cestereg.api.quiz.controller;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+import static org.springframework.http.MediaType.APPLICATION_JSON;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.options;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.cevapinxile.cestereg.api.quiz.dto.request.CreateTeamRequest;
+import com.cevapinxile.cestereg.api.quiz.dto.response.CreateTeamResponse;
+import com.cevapinxile.cestereg.api.support.ControllerTestSupport;
+import com.cevapinxile.cestereg.core.service.TeamService;
+import java.util.UUID;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.ArgumentCaptor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(TeamController.class)
+class TeamControllerTest extends ControllerTestSupport {
+
+  @Autowired private MockMvc mockMvc;
+
+  @MockitoBean private TeamService teamService;
+
+  @Nested
+  class CreateTeamTests {
+
+    @Test
+    void createTeamReturnsSerializedResponse() throws Exception {
+      UUID id = UUID.randomUUID();
+      when(teamService.createTeam(any(), eq("AKKU")))
+          .thenReturn(new CreateTeamResponse(id, "Team Cyan", "team.png"));
+
+      mockMvc
+          .perform(
+              post("/api/v1/games/{roomCode}/teams", "AKKU")
+                  .contentType(APPLICATION_JSON)
+                  .content(
+                      "{\"name\":\"Team Cyan\",\"buttonCode\":\"BTN-1\",\"image\":\"team.png\"}"))
+          .andExpect(status().isOk())
+          .andExpect(content().contentTypeCompatibleWith(APPLICATION_JSON))
+          .andExpect(jsonPath("$.id").value(id.toString()))
+          .andExpect(jsonPath("$.name").value("Team Cyan"))
+          .andExpect(jsonPath("$.image").value("team.png"));
+
+      ArgumentCaptor<CreateTeamRequest> captor = ArgumentCaptor.forClass(CreateTeamRequest.class);
+      verify(teamService).createTeam(captor.capture(), eq("AKKU"));
+      CreateTeamRequest request = captor.getValue();
+      assertEquals("Team Cyan", request.name());
+      assertEquals("BTN-1", request.buttonCode());
+      assertEquals("team.png", request.image());
+    }
+
+    @Test
+    void createTeamReturnsBadRequestForMissingBody() throws Exception {
+      mockMvc
+          .perform(post("/api/v1/games/{roomCode}/teams", "AKKU"))
+          .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void createTeamForwardsNullFieldsWhenPayloadOmitsParameters() throws Exception {
+      when(teamService.createTeam(any(), eq("AKKU")))
+          .thenReturn(new CreateTeamResponse(UUID.randomUUID(), "Fallback", "fallback.png"));
+
+      mockMvc
+          .perform(
+              post("/api/v1/games/{roomCode}/teams", "AKKU")
+                  .contentType(APPLICATION_JSON)
+                  .content("{}"))
+          .andExpect(status().isOk())
+          .andExpect(content().contentTypeCompatibleWith(APPLICATION_JSON));
+
+      ArgumentCaptor<CreateTeamRequest> captor = ArgumentCaptor.forClass(CreateTeamRequest.class);
+      verify(teamService).createTeam(captor.capture(), eq("AKKU"));
+      assertNull(captor.getValue().name());
+      assertNull(captor.getValue().buttonCode());
+      assertNull(captor.getValue().image());
+    }
+
+    @Test
+    void createTeamDoesNotValidateRoomCodeFormatAtControllerLevel() throws Exception {
+      when(teamService.createTeam(any(), eq("abc")))
+          .thenReturn(new CreateTeamResponse(UUID.randomUUID(), "Team", "img"));
+
+      mockMvc
+          .perform(
+              post("/api/v1/games/{roomCode}/teams", "abc")
+                  .contentType(APPLICATION_JSON)
+                  .content("{\"name\":\"Team\",\"buttonCode\":\"BTN-1\",\"image\":\"img\"}"))
+          .andExpect(status().isOk());
+
+      verify(teamService).createTeam(any(), eq("abc"));
+    }
+
+    @ParameterizedTest
+    @MethodSource("derivedExceptionsForCreateTeam")
+    void createTeamMapsDerivedExceptions(int status, String code, String title, String message)
+        throws Exception {
+      when(teamService.createTeam(any(), eq("AKKU")))
+          .thenThrow(derived(status, code, title, message));
+
+      mockMvc
+          .perform(
+              post("/api/v1/games/{roomCode}/teams", "AKKU")
+                  .contentType(APPLICATION_JSON)
+                  .content(
+                      "{\"name\":\"Team Cyan\",\"buttonCode\":\"BTN-1\",\"image\":\"team.png\"}"))
+          .andExpect(status().is(status))
+          .andExpect(content().contentTypeCompatibleWith(APPLICATION_JSON))
+          .andExpect(
+              content()
+                  .string(
+                      "{\"error\":\"E"
+                          + code
+                          + " - "
+                          + title
+                          + "\", \"message\":\""
+                          + message
+                          + "\"}"));
+    }
+
+    @Test
+    void createTeamReturnsInternalServerErrorForUnexpectedException() throws Exception {
+      when(teamService.createTeam(any(), eq("AKKU"))).thenThrow(new RuntimeException("boom"));
+
+      mockMvc
+          .perform(
+              post("/api/v1/games/{roomCode}/teams", "AKKU")
+                  .contentType(APPLICATION_JSON)
+                  .content(
+                      "{\"name\":\"Team Cyan\",\"buttonCode\":\"BTN-1\",\"image\":\"team.png\"}"))
+          .andExpect(status().isInternalServerError())
+          .andExpect(content().contentTypeCompatibleWith(APPLICATION_JSON));
+    }
+
+    @Test
+    void createTeamAddsCorsHeaderWhenOriginPresent() throws Exception {
+      when(teamService.createTeam(any(), eq("AKKU")))
+          .thenReturn(new CreateTeamResponse(UUID.randomUUID(), "Team", "img"));
+
+      mockMvc
+          .perform(
+              post("/api/v1/games/{roomCode}/teams", "AKKU")
+                  .header("Origin", "https://example.com")
+                  .contentType(APPLICATION_JSON)
+                  .content("{\"name\":\"Team\",\"buttonCode\":\"BTN-1\",\"image\":\"img\"}"))
+          .andExpect(status().isOk())
+          .andExpect(header().string("Access-Control-Allow-Origin", "*"));
+    }
+
+    static Stream<Arguments> derivedExceptionsForCreateTeam() {
+      return Stream.of(
+          Arguments.of(
+              400, "000", "An argument is missing", "name, buttonCode, and image are required."),
+          Arguments.of(404, "001", "Invalid referenced object", "Game or button not found."),
+          Arguments.of(409, "003", "Wrong game-state", "Teams can only be created in stage 0."));
+    }
+  }
+
+  @Nested
+  class KickTeamTests {
+
+    @Test
+    void kickTeamReturnsOkAndForwardsIds() throws Exception {
+      mockMvc
+          .perform(delete("/api/v1/games/{roomCode}/teams/{teamId}", "AKKU", "team-42"))
+          .andExpect(status().isOk())
+          .andExpect(content().string(""));
+
+      verify(teamService).kickTeam("team-42", "AKKU");
+    }
+
+    @Test
+    void kickTeamDoesNotValidateTeamIdFormatAtControllerLevel() throws Exception {
+      mockMvc
+          .perform(delete("/api/v1/games/{roomCode}/teams/{teamId}", "AKKU", "not-a-uuid"))
+          .andExpect(status().isOk());
+
+      verify(teamService).kickTeam("not-a-uuid", "AKKU");
+    }
+
+    @Test
+    void kickTeamDoesNotValidateRoomCodeFormatAtControllerLevel() throws Exception {
+      mockMvc
+          .perform(delete("/api/v1/games/{roomCode}/teams/{teamId}", "abc", "team-42"))
+          .andExpect(status().isOk());
+
+      verify(teamService).kickTeam("team-42", "abc");
+    }
+
+    @ParameterizedTest
+    @MethodSource("derivedExceptionsForKickTeam")
+    void kickTeamMapsDerivedExceptions(int status, String code, String title, String message)
+        throws Exception {
+      doThrow(derived(status, code, title, message)).when(teamService).kickTeam("team-42", "AKKU");
+
+      mockMvc
+          .perform(delete("/api/v1/games/{roomCode}/teams/{teamId}", "AKKU", "team-42"))
+          .andExpect(status().is(status))
+          .andExpect(content().contentTypeCompatibleWith(APPLICATION_JSON))
+          .andExpect(
+              content()
+                  .string(
+                      "{\"error\":\"E"
+                          + code
+                          + " - "
+                          + title
+                          + "\", \"message\":\""
+                          + message
+                          + "\"}"));
+    }
+
+    @Test
+    void kickTeamReturnsInternalServerErrorForUnexpectedException() throws Exception {
+      doThrow(new RuntimeException("boom")).when(teamService).kickTeam("team-42", "AKKU");
+
+      mockMvc
+          .perform(delete("/api/v1/games/{roomCode}/teams/{teamId}", "AKKU", "team-42"))
+          .andExpect(status().isInternalServerError())
+          .andExpect(content().contentTypeCompatibleWith(APPLICATION_JSON));
+    }
+
+    @Test
+    void kickTeamAddsCorsHeaderWhenOriginPresent() throws Exception {
+      mockMvc
+          .perform(
+              delete("/api/v1/games/{roomCode}/teams/{teamId}", "AKKU", "team-42")
+                  .header("Origin", "https://example.com"))
+          .andExpect(status().isOk())
+          .andExpect(header().string("Access-Control-Allow-Origin", "*"));
+    }
+
+    static Stream<Arguments> derivedExceptionsForKickTeam() {
+      return Stream.of(
+          Arguments.of(404, "001", "Invalid referenced object", "Game or team not found."),
+          Arguments.of(
+              409, "003", "Wrong game-state", "Kicking teams is only allowed in stage 0."));
+    }
+  }
+
+  @Nested
+  class CreateTeamContract {
+
+    @Test
+    void createTeamRejectsUnsupportedMethod() throws Exception {
+      mockMvc
+          .perform(get("/api/v1/games/{roomCode}/teams", "AKKU"))
+          .andExpect(status().isMethodNotAllowed());
+      verifyNoInteractions(teamService);
+    }
+
+    @Test
+    void createTeamRejectsUnsupportedMediaType() throws Exception {
+      mockMvc
+          .perform(
+              post("/api/v1/games/{roomCode}/teams", "AKKU").contentType("text/plain").content("x"))
+          .andExpect(status().isUnsupportedMediaType());
+      verifyNoInteractions(teamService);
+    }
+
+    @Test
+    void createTeamPreflightReturnsCorsHeaders() throws Exception {
+      mockMvc
+          .perform(
+              options("/api/v1/games/{roomCode}/teams", "AKKU")
+                  .header("Origin", "https://example.com")
+                  .header("Access-Control-Request-Method", "POST"))
+          .andExpect(status().isOk())
+          .andExpect(header().string("Access-Control-Allow-Origin", "*"));
+    }
+
+    @Test
+    void createTeamMalformedJsonDoesNotCallService() throws Exception {
+      mockMvc
+          .perform(
+              post("/api/v1/games/{roomCode}/teams", "AKKU")
+                  .contentType(APPLICATION_JSON)
+                  .content("{\"name\":"))
+          .andExpect(status().isBadRequest());
+      verifyNoInteractions(teamService);
+    }
+  }
+
+  @Nested
+  class KickTeamContract {
+
+    @Test
+    void kickTeamRejectsUnsupportedMethod() throws Exception {
+      mockMvc
+          .perform(post("/api/v1/games/{roomCode}/teams/{teamId}", "AKKU", "team-1"))
+          .andExpect(status().isMethodNotAllowed());
+      verifyNoInteractions(teamService);
+    }
+
+    @Test
+    void kickTeamReturnsEmptyBodyOnSuccess() throws Exception {
+      mockMvc
+          .perform(delete("/api/v1/games/{roomCode}/teams/{teamId}", "AKKU", "team-1"))
+          .andExpect(status().isOk())
+          .andExpect(content().string(""));
+    }
+
+    @Test
+    void kickTeamPreflightReturnsCorsHeaders() throws Exception {
+      mockMvc
+          .perform(
+              options("/api/v1/games/{roomCode}/teams/{teamId}", "AKKU", "team-1")
+                  .header("Origin", "https://example.com")
+                  .header("Access-Control-Request-Method", "DELETE"))
+          .andExpect(status().isOk())
+          .andExpect(header().string("Access-Control-Allow-Origin", "*"));
+    }
+  }
+
+  @Nested
+  class CreateTeamBinding {
+
+    @Test
+    void createTeamCoercesNumericNameToStringAndForwardsIt() throws Exception {
+      when(teamService.createTeam(any(), eq("AKKU")))
+          .thenReturn(new CreateTeamResponse(UUID.randomUUID(), "123", "img"));
+
+      mockMvc
+          .perform(
+              post("/api/v1/games/{roomCode}/teams", "AKKU")
+                  .contentType(APPLICATION_JSON)
+                  .content("{\"name\":123,\"buttonCode\":\"BTN-1\",\"image\":\"team.png\"}"))
+          .andExpect(status().isOk());
+
+      ArgumentCaptor<CreateTeamRequest> captor = ArgumentCaptor.forClass(CreateTeamRequest.class);
+      verify(teamService).createTeam(captor.capture(), eq("AKKU"));
+      assertEquals("123", captor.getValue().name());
+    }
+
+    @Test
+    void createTeamAllowsNullNameAndForwardsItToService() throws Exception {
+      when(teamService.createTeam(any(), eq("AKKU")))
+          .thenReturn(new CreateTeamResponse(UUID.randomUUID(), "Fallback", "img"));
+
+      mockMvc
+          .perform(
+              post("/api/v1/games/{roomCode}/teams", "AKKU")
+                  .contentType(APPLICATION_JSON)
+                  .content("{\"name\":null,\"buttonCode\":\"BTN-1\",\"image\":\"team.png\"}"))
+          .andExpect(status().isOk());
+
+      ArgumentCaptor<CreateTeamRequest> captor = ArgumentCaptor.forClass(CreateTeamRequest.class);
+      verify(teamService).createTeam(captor.capture(), eq("AKKU"));
+      assertNull(captor.getValue().name());
+      assertEquals("BTN-1", captor.getValue().buttonCode());
+      assertEquals("team.png", captor.getValue().image());
+    }
+
+    @Test
+    void createTeamUnknownFieldsAreIgnoredWhenMainPayloadIsValid() throws Exception {
+      UUID id = UUID.randomUUID();
+      when(teamService.createTeam(any(), eq("AKKU")))
+          .thenReturn(new CreateTeamResponse(id, "Team", "img"));
+
+      mockMvc
+          .perform(
+              post("/api/v1/games/{roomCode}/teams", "AKKU")
+                  .contentType(APPLICATION_JSON)
+                  .content(
+                      "{\"name\":\"Team\",\"buttonCode\":\"BTN-1\",\"image\":\"img\",\"extra\":\"ignored\"}"))
+          .andExpect(status().isOk())
+          .andExpect(content().json("{\"id\":\"" + id + "\",\"name\":\"Team\",\"image\":\"img\"}"));
+    }
+  }
+}

--- a/apps/backend/src/test/java/com/cevapinxile/cestereg/api/support/AdditionalControllerTestSupport.java
+++ b/apps/backend/src/test/java/com/cevapinxile/cestereg/api/support/AdditionalControllerTestSupport.java
@@ -1,0 +1,25 @@
+package com.cevapinxile.cestereg.api.support;
+
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.springframework.http.MediaType.APPLICATION_JSON;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+
+import org.springframework.test.web.servlet.ResultActions;
+
+public abstract class AdditionalControllerTestSupport extends ControllerTestSupport {
+
+  protected void expectJsonUtf8(ResultActions actions) throws Exception {
+    actions.andExpect(content().contentTypeCompatibleWith(APPLICATION_JSON));
+  }
+
+  protected void expectCorsWildcard(ResultActions actions) throws Exception {
+    actions.andExpect(header().string("Access-Control-Allow-Origin", "*"));
+  }
+
+  protected void expectNoServiceCalls(Object... mocks) {
+    for (Object mock : mocks) {
+      verifyNoInteractions(mock);
+    }
+  }
+}

--- a/apps/backend/src/test/java/com/cevapinxile/cestereg/api/support/ControllerTestSupport.java
+++ b/apps/backend/src/test/java/com/cevapinxile/cestereg/api/support/ControllerTestSupport.java
@@ -1,0 +1,17 @@
+package com.cevapinxile.cestereg.api.support;
+
+import com.cevapinxile.cestereg.common.exception.DerivedException;
+
+public abstract class ControllerTestSupport {
+
+  protected static FakeDerivedException derived(
+      int status, String code, String title, String message) {
+    return new FakeDerivedException(status, code, title, message);
+  }
+
+  protected static final class FakeDerivedException extends DerivedException {
+    private FakeDerivedException(int status, String code, String title, String message) {
+      super(status, code, title, message);
+    }
+  }
+}

--- a/apps/frontend/package-lock.json
+++ b/apps/frontend/package-lock.json
@@ -29,19 +29,12 @@
         "@typescript-eslint/parser": "^8.57.0",
         "eslint": "^10.0.3",
         "eslint-plugin-unused-imports": "^4.4.1",
-        "jsdom": "^28.1.0",
+        "jsdom": "^29.0.0",
         "prettier": "^3.8.1",
         "typescript": "~5.9.2",
         "typescript-eslint": "^8.57.0",
         "vitest": "^4.1.0"
       }
-    },
-    "node_modules/@acemir/cssom": {
-      "version": "0.9.31",
-      "resolved": "https://registry.npmjs.org/@acemir/cssom/-/cssom-0.9.31.tgz",
-      "integrity": "sha512-ZnR3GSaH+/vJ0YlHau21FjfLYjMpYVIzTD8M8vIEQvIGxeOXyXdzCI140rrCY862p/C/BbzWsjc1dgnM9mkoTA==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/@algolia/abtesting": {
       "version": "1.14.1",
@@ -437,7 +430,7 @@
         "semver": "7.7.4",
         "source-map-support": "0.5.21",
         "tinyglobby": "0.2.15",
-        "undici": "7.22.0",
+        "undici": "7.24.3",
         "vite": "7.3.1",
         "watchpack": "2.5.1"
       },
@@ -704,9 +697,9 @@
       }
     },
     "node_modules/@asamuzakjp/css-color/node_modules/lru-cache": {
-      "version": "11.2.6",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.6.tgz",
-      "integrity": "sha512-ESL2CrkS/2wTPfuend7Zhkzo2u0daGJ/A2VucJOgQ/C48S/zB8MMeMHSGKYpXhIjbPxfuezITkaBH1wqv00DDQ==",
+      "version": "11.2.7",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.7.tgz",
+      "integrity": "sha512-aY/R+aEsRelme17KGQa/1ZSIpLpNYYrhcrepKTZgE+W3WM16YMCaPwOHLHsmopZHELU0Ojin1lPVxKR0MihncA==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "engines": {
@@ -714,23 +707,26 @@
       }
     },
     "node_modules/@asamuzakjp/dom-selector": {
-      "version": "6.8.1",
-      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-6.8.1.tgz",
-      "integrity": "sha512-MvRz1nCqW0fsy8Qz4dnLIvhOlMzqDVBabZx6lH+YywFDdjXhMY37SmpV1XFX3JzG5GWHn63j6HX6QPr3lZXHvQ==",
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-7.0.3.tgz",
+      "integrity": "sha512-Q6mU0Z6bfj6YvnX2k9n0JxiIwrCFN59x/nWmYQnAqP000ruX/yV+5bp/GRcF5T8ncvfwJQ7fgfP74DlpKExILA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@asamuzakjp/nwsapi": "^2.3.9",
         "bidi-js": "^1.0.3",
-        "css-tree": "^3.1.0",
+        "css-tree": "^3.2.1",
         "is-potential-custom-element-name": "^1.0.1",
-        "lru-cache": "^11.2.6"
+        "lru-cache": "^11.2.7"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       }
     },
     "node_modules/@asamuzakjp/dom-selector/node_modules/lru-cache": {
-      "version": "11.2.6",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.6.tgz",
-      "integrity": "sha512-ESL2CrkS/2wTPfuend7Zhkzo2u0daGJ/A2VucJOgQ/C48S/zB8MMeMHSGKYpXhIjbPxfuezITkaBH1wqv00DDQ==",
+      "version": "11.2.7",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.7.tgz",
+      "integrity": "sha512-aY/R+aEsRelme17KGQa/1ZSIpLpNYYrhcrepKTZgE+W3WM16YMCaPwOHLHsmopZHELU0Ojin1lPVxKR0MihncA==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "engines": {
@@ -1146,9 +1142,9 @@
       }
     },
     "node_modules/@csstools/css-syntax-patches-for-csstree": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.0.tgz",
-      "integrity": "sha512-H4tuz2nhWgNKLt1inYpoVCfbJbMwX/lQKp3g69rrrIMIYlFD9+zTykOKhNR8uGrAmbS/kT9n6hTFkmDkxLgeTA==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.1.tgz",
+      "integrity": "sha512-BvqN0AMWNAnLk9G8jnUT77D+mUbY/H2b3uDTvg2isJkHaOufUE2R3AOwxWo7VBQKT1lOdwdvorddo2B/lk64+w==",
       "dev": true,
       "funding": [
         {
@@ -1160,7 +1156,15 @@
           "url": "https://opencollective.com/csstools"
         }
       ],
-      "license": "MIT-0"
+      "license": "MIT-0",
+      "peerDependencies": {
+        "css-tree": "^3.2.1"
+      },
+      "peerDependenciesMeta": {
+        "css-tree": {
+          "optional": true
+        }
+      }
     },
     "node_modules/@csstools/css-tokenizer": {
       "version": "4.0.0",
@@ -5287,32 +5291,6 @@
         "url": "https://github.com/sponsors/fb55"
       }
     },
-    "node_modules/cssstyle": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-6.2.0.tgz",
-      "integrity": "sha512-Fm5NvhYathRnXNVndkUsCCuR63DCLVVwGOOwQw782coXFi5HhkXdu289l59HlXZBawsyNccXfWRYvLzcDCdDig==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@asamuzakjp/css-color": "^5.0.1",
-        "@csstools/css-syntax-patches-for-csstree": "^1.0.28",
-        "css-tree": "^3.1.0",
-        "lru-cache": "^11.2.6"
-      },
-      "engines": {
-        "node": ">=20"
-      }
-    },
-    "node_modules/cssstyle/node_modules/lru-cache": {
-      "version": "11.2.6",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.6.tgz",
-      "integrity": "sha512-ESL2CrkS/2wTPfuend7Zhkzo2u0daGJ/A2VucJOgQ/C48S/zB8MMeMHSGKYpXhIjbPxfuezITkaBH1wqv00DDQ==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "engines": {
-        "node": "20 || >=22"
-      }
-    },
     "node_modules/data-urls": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
@@ -6701,36 +6679,36 @@
       "license": "MIT"
     },
     "node_modules/jsdom": {
-      "version": "28.1.0",
-      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-28.1.0.tgz",
-      "integrity": "sha512-0+MoQNYyr2rBHqO1xilltfDjV9G7ymYGlAUazgcDLQaUf8JDHbuGwsxN6U9qWaElZ4w1B2r7yEGIL3GdeW3Rug==",
+      "version": "29.0.0",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-29.0.0.tgz",
+      "integrity": "sha512-9FshNB6OepopZ08unmmGpsF7/qCjxGPbo3NbgfJAnPeHXnsODE9WWffXZtRFRFe0ntzaAOcSKNJFz8wiyvF1jQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@acemir/cssom": "^0.9.31",
-        "@asamuzakjp/dom-selector": "^6.8.1",
+        "@asamuzakjp/css-color": "^5.0.1",
+        "@asamuzakjp/dom-selector": "^7.0.2",
         "@bramus/specificity": "^2.4.2",
-        "@exodus/bytes": "^1.11.0",
-        "cssstyle": "^6.0.1",
+        "@csstools/css-syntax-patches-for-csstree": "^1.1.1",
+        "@exodus/bytes": "^1.15.0",
+        "css-tree": "^3.2.1",
         "data-urls": "^7.0.0",
         "decimal.js": "^10.6.0",
         "html-encoding-sniffer": "^6.0.0",
-        "http-proxy-agent": "^7.0.2",
-        "https-proxy-agent": "^7.0.6",
         "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.2.7",
         "parse5": "^8.0.0",
         "saxes": "^6.0.0",
         "symbol-tree": "^3.2.4",
-        "tough-cookie": "^6.0.0",
-        "undici": "^7.21.0",
+        "tough-cookie": "^6.0.1",
+        "undici": "^7.24.3",
         "w3c-xmlserializer": "^5.0.0",
         "webidl-conversions": "^8.0.1",
         "whatwg-mimetype": "^5.0.0",
-        "whatwg-url": "^16.0.0",
+        "whatwg-url": "^16.0.1",
         "xml-name-validator": "^5.0.0"
       },
       "engines": {
-        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+        "node": "^20.19.0 || ^22.13.0 || >=24.0.0"
       },
       "peerDependencies": {
         "canvas": "^3.0.0"
@@ -6739,6 +6717,16 @@
         "canvas": {
           "optional": true
         }
+      }
+    },
+    "node_modules/jsdom/node_modules/lru-cache": {
+      "version": "11.2.7",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.7.tgz",
+      "integrity": "sha512-aY/R+aEsRelme17KGQa/1ZSIpLpNYYrhcrepKTZgE+W3WM16YMCaPwOHLHsmopZHELU0Ojin1lPVxKR0MihncA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
       }
     },
     "node_modules/jsesc": {
@@ -9075,9 +9063,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "7.22.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.22.0.tgz",
-      "integrity": "sha512-RqslV2Us5BrllB+JeiZnK4peryVTndy9Dnqq62S3yYRRTj0tFQCwEniUy2167skdGOy3vqRzEvl1Dm4sV2ReDg==",
+      "version": "7.24.3",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.24.3.tgz",
+      "integrity": "sha512-eJdUmK/Wrx2d+mnWWmwwLRyA7OQCkLap60sk3dOK4ViZR7DKwwptwuIvFBg2HaiP9ESaEdhtpSymQPvytpmkCA==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -48,7 +48,7 @@
     "@typescript-eslint/parser": "^8.57.0",
     "eslint": "^10.0.3",
     "eslint-plugin-unused-imports": "^4.4.1",
-    "jsdom": "^28.1.0",
+    "jsdom": "^29.0.0",
     "prettier": "^3.8.1",
     "typescript": "~5.9.2",
     "typescript-eslint": "^8.57.0",

--- a/docs/developer-guide/testing/test-catalog.csv
+++ b/docs/developer-guide/testing/test-catalog.csv
@@ -284,3 +284,166 @@ runtime/websocket/RuntimeWebsocketTest.java,GameCodeExtractorTest,beforeHandshak
 consistency/TestCatalogConsistencyTest.java,,testCatalogMustMatchCode,Tests and this document are consistent with each other,5
 consistency/ExceptionCatalogConsistencyTest.java,,exceptionCatalogMustMatchCode,Exceptions and exception catalog must be consistent with each other,5
 consistency/SwaggerConsistencyTest.java,,swaggerContractMustBeStructurallyConsistent,All API endpoints must be properly documented via Swagger,5
+api/quiz/controller/GameControllerTest.java,CreateGameTests,createGameReturnsRoomCodeResponse,Create Game Returns Room Code Response.,9
+api/quiz/controller/GameControllerTest.java,CreateGameTests,createGameReturnsBadRequestForMissingBody,Create Game Returns Bad Request For Missing Body.,7
+api/quiz/controller/GameControllerTest.java,CreateGameTests,createGameReturnsBadRequestForMalformedJson,Create Game Returns Bad Request For Malformed JSON.,7
+api/quiz/controller/GameControllerTest.java,CreateGameTests,createGameForwardsNullFieldsWhenPayloadOmitsParameters,Create Game Forwards Null Fields When Payload Omits Parameters.,6
+api/quiz/controller/GameControllerTest.java,CreateGameTests,createGameMapsDerivedException,Create Game Maps Derived Exception.,9
+api/quiz/controller/GameControllerTest.java,CreateGameTests,createGameReturnsInternalServerErrorForUnexpectedException,Create Game Returns Internal Server Error For Unexpected Exception.,9
+api/quiz/controller/GameControllerTest.java,CreateGameTests,createGameAddsCorsHeaderWhenOriginPresent,Create Game Adds Cors Header When Origin Present.,6
+api/quiz/controller/GameControllerTest.java,ChangeStageTests,changeStageReturnsOkAndForwardsStageId,Change Stage Returns Ok And Forwards Stage Id.,6
+api/quiz/controller/GameControllerTest.java,ChangeStageTests,changeStageReturnsBadRequestForMissingBody,Change Stage Returns Bad Request For Missing Body.,7
+api/quiz/controller/GameControllerTest.java,ChangeStageTests,changeStageReturnsBadRequestForMalformedJson,Change Stage Returns Bad Request For Malformed JSON.,7
+api/quiz/controller/GameControllerTest.java,ChangeStageTests,changeStageReturnsBadRequestWhenStageIdMissingFromPayload,Change Stage Returns Bad Request When Stage Id Missing From Payload.,9
+api/quiz/controller/GameControllerTest.java,ChangeStageTests,changeStageDoesNotRejectInvalidRoomCodeAtControllerLevel,Change Stage Does Not Reject Invalid Room Code At Controller Level.,8
+api/quiz/controller/GameControllerTest.java,ChangeStageTests,changeStageMapsDerivedException,Change Stage Maps Derived Exception.,9
+api/quiz/controller/GameControllerTest.java,ChangeStageTests,changeStageReturnsInternalServerErrorForUnexpectedException,Change Stage Returns Internal Server Error For Unexpected Exception.,9
+api/quiz/controller/GameControllerTest.java,ChangeStageTests,changeStageAddsCorsHeaderWhenOriginPresent,Change Stage Adds Cors Header When Origin Present.,6
+api/quiz/controller/GameControllerTest.java,CreateGameContract,createGameRejectsUnsupportedMethod,Create Game Rejects Unsupported Method.,7
+api/quiz/controller/GameControllerTest.java,CreateGameContract,createGameRejectsUnsupportedMediaType,Create Game Rejects Unsupported Media Type.,7
+api/quiz/controller/GameControllerTest.java,CreateGameContract,createGamePreflightReturnsCorsHeaders,Create Game Preflight Returns Cors Headers.,6
+api/quiz/controller/GameControllerTest.java,CreateGameContract,createGameMalformedJsonDoesNotCallService,Create Game Malformed JSON Does Not Call Service.,8
+api/quiz/controller/GameControllerTest.java,ChangeStageContract,changeStageRejectsUnsupportedMethod,Change Stage Rejects Unsupported Method.,7
+api/quiz/controller/GameControllerTest.java,ChangeStageContract,changeStageRejectsUnsupportedMediaType,Change Stage Rejects Unsupported Media Type.,7
+api/quiz/controller/GameControllerTest.java,ChangeStageContract,changeStageReturnsEmptyBodyOnSuccess,Change Stage Returns Empty Body On Success.,8
+api/quiz/controller/GameControllerTest.java,ChangeStageContract,changeStagePreflightReturnsCorsHeaders,Change Stage Preflight Returns Cors Headers.,6
+api/quiz/controller/GameControllerTest.java,ChangeStageContract,changeStageMalformedJsonDoesNotCallService,Change Stage Malformed JSON Does Not Call Service.,8
+api/quiz/controller/GameControllerTest.java,CreateGameBinding,createGameRejectsStringForNumericField,Create Game Rejects String For Numeric Field.,7
+api/quiz/controller/GameControllerTest.java,CreateGameBinding,createGameAllowsNullMaxSongsAndForwardsIt,Create Game Allows Null Max Songs And Forwards It.,6
+api/quiz/controller/GameControllerTest.java,CreateGameBinding,createGameUnknownFieldBehaviorIsDocumented,Create Game Unknown Field Behavior Is Documented.,8
+api/quiz/controller/GameControllerTest.java,ChangeStageBinding,changeStageRejectsStringForStageId,Change Stage Rejects String For Stage Id.,7
+api/quiz/controller/GameControllerTest.java,ChangeStageBinding,changeStageRejectsExplicitNullStageId,Change Stage Rejects Explicit Null Stage Id.,7
+api/quiz/controller/GameControllerTest.java,ChangeStageBinding,changeStageIgnoresUnknownFieldsWhenMainPayloadIsValid,Change Stage Ignores Unknown Fields When Main Payload Is Valid.,6
+api/quiz/controller/CategoryControllerTest.java,PickAlbumTests,pickAlbumReturnsSerializedLastCategory,Pick Album Returns Serialized Last Category.,8
+api/quiz/controller/CategoryControllerTest.java,PickAlbumTests,pickAlbumReturnsBadRequestForMissingBody,Pick Album Returns Bad Request For Missing Body.,7
+api/quiz/controller/CategoryControllerTest.java,PickAlbumTests,pickAlbumReturnsBadRequestForMalformedCategoryUuid,Pick Album Returns Bad Request For Malformed Category UUID.,7
+api/quiz/controller/CategoryControllerTest.java,PickAlbumTests,pickAlbumForwardsNullTeamIdWhenPayloadOmitsIt,Pick Album Forwards Null Team Id When Payload Omits It.,6
+api/quiz/controller/CategoryControllerTest.java,PickAlbumTests,pickAlbumDoesNotValidateRoomCodeFormatAtControllerLevel,Pick Album Does Not Validate Room Code Format At Controller Level.,6
+api/quiz/controller/CategoryControllerTest.java,PickAlbumTests,pickAlbumMapsDerivedExceptions,Pick Album Maps Derived Exceptions.,9
+api/quiz/controller/CategoryControllerTest.java,PickAlbumTests,pickAlbumReturnsInternalServerErrorForUnexpectedException,Pick Album Returns Internal Server Error For Unexpected Exception.,9
+api/quiz/controller/CategoryControllerTest.java,PickAlbumTests,pickAlbumAddsCorsHeaderWhenOriginPresent,Pick Album Adds Cors Header When Origin Present.,6
+api/quiz/controller/CategoryControllerTest.java,StartCategoryTests,startCategoryReturnsOk,Start Category Returns Ok.,8
+api/quiz/controller/CategoryControllerTest.java,StartCategoryTests,startCategoryDoesNotValidateRoomCodeFormatAtControllerLevel,Start Category Does Not Validate Room Code Format At Controller Level.,6
+api/quiz/controller/CategoryControllerTest.java,StartCategoryTests,startCategoryMapsDerivedExceptions,Start Category Maps Derived Exceptions.,9
+api/quiz/controller/CategoryControllerTest.java,StartCategoryTests,startCategoryReturnsInternalServerErrorForUnexpectedException,Start Category Returns Internal Server Error For Unexpected Exception.,9
+api/quiz/controller/CategoryControllerTest.java,StartCategoryTests,startCategoryAddsCorsHeaderWhenOriginPresent,Start Category Adds Cors Header When Origin Present.,6
+api/quiz/controller/CategoryControllerTest.java,PickAlbumContract,pickAlbumRejectsUnsupportedMethod,Pick Album Rejects Unsupported Method.,7
+api/quiz/controller/CategoryControllerTest.java,PickAlbumContract,pickAlbumRejectsUnsupportedMediaType,Pick Album Rejects Unsupported Media Type.,7
+api/quiz/controller/CategoryControllerTest.java,PickAlbumContract,pickAlbumMalformedJsonDoesNotCallService,Pick Album Malformed JSON Does Not Call Service.,8
+api/quiz/controller/CategoryControllerTest.java,PickAlbumContract,pickAlbumPreflightReturnsCorsHeaders,Pick Album Preflight Returns Cors Headers.,6
+api/quiz/controller/CategoryControllerTest.java,StartCategoryContract,startCategoryRejectsUnsupportedMethod,Start Category Rejects Unsupported Method.,7
+api/quiz/controller/CategoryControllerTest.java,StartCategoryContract,startCategoryPreflightReturnsCorsHeaders,Start Category Preflight Returns Cors Headers.,6
+api/quiz/controller/CategoryControllerTest.java,StartCategoryContract,malformedCategoryIdDoesNotCallService,Malformed Category Id Does Not Call Service.,8
+api/quiz/controller/CategoryControllerTest.java,PickAlbumBinding,pickAlbumRejectsNumericTeamId,Pick Album Rejects Numeric Team Id.,7
+api/quiz/controller/CategoryControllerTest.java,PickAlbumBinding,pickAlbumAllowsExplicitNullTeamIdAndForwardsIt,Pick Album Allows Explicit Null Team Id And Forwards It.,6
+api/quiz/controller/CategoryControllerTest.java,PickAlbumBinding,pickAlbumIgnoresUnknownFieldsWhenMainPayloadIsValid,Pick Album Ignores Unknown Fields When Main Payload Is Valid.,6
+api/quiz/controller/InterruptControllerTest.java,InterruptTests,interruptReturnsOkAndForwardsTeamId,Interrupt Returns Ok And Forwards Team Id.,6
+api/quiz/controller/InterruptControllerTest.java,InterruptTests,interruptAllowsSystemInterruptByForwardingNullTeamId,Interrupt Allows System Interrupt By Forwarding Null Team Id.,6
+api/quiz/controller/InterruptControllerTest.java,InterruptTests,interruptReturnsBadRequestForMissingBody,Interrupt Returns Bad Request For Missing Body.,7
+api/quiz/controller/InterruptControllerTest.java,InterruptTests,interruptDoesNotValidateRoomCodeFormatAtControllerLevel,Interrupt Does Not Validate Room Code Format At Controller Level.,6
+api/quiz/controller/InterruptControllerTest.java,InterruptTests,interruptMapsDerivedExceptions,Interrupt Maps Derived Exceptions.,9
+api/quiz/controller/InterruptControllerTest.java,InterruptTests,interruptReturnsInternalServerErrorForUnexpectedException,Interrupt Returns Internal Server Error For Unexpected Exception.,9
+api/quiz/controller/InterruptControllerTest.java,InterruptTests,interruptAddsCorsHeaderWhenOriginPresent,Interrupt Adds Cors Header When Origin Present.,6
+api/quiz/controller/InterruptControllerTest.java,ResolveErrorsTests,resolveErrorsReturnsOkAndForwardsScheduleId,Resolve Errors Returns Ok And Forwards Schedule Id.,6
+api/quiz/controller/InterruptControllerTest.java,ResolveErrorsTests,resolveErrorsReturnsBadRequestForMissingBody,Resolve Errors Returns Bad Request For Missing Body.,7
+api/quiz/controller/InterruptControllerTest.java,ResolveErrorsTests,resolveErrorsForwardsNullScheduleIdWhenPayloadOmitsIt,Resolve Errors Forwards Null Schedule Id When Payload Omits It.,6
+api/quiz/controller/InterruptControllerTest.java,ResolveErrorsTests,resolveErrorsMapsDerivedExceptions,Resolve Errors Maps Derived Exceptions.,9
+api/quiz/controller/InterruptControllerTest.java,ResolveErrorsTests,resolveErrorsReturnsInternalServerErrorForUnexpectedException,Resolve Errors Returns Internal Server Error For Unexpected Exception.,9
+api/quiz/controller/InterruptControllerTest.java,ResolveErrorsTests,resolveErrorsAddsCorsHeaderWhenOriginPresent,Resolve Errors Adds Cors Header When Origin Present.,6
+api/quiz/controller/InterruptControllerTest.java,AnswerTests,answerReturnsOkAndForwardsAnswerRequest,Answer Returns Ok And Forwards Answer Request.,6
+api/quiz/controller/InterruptControllerTest.java,AnswerTests,answerReturnsBadRequestForMissingBody,Answer Returns Bad Request For Missing Body.,7
+api/quiz/controller/InterruptControllerTest.java,AnswerTests,answerReturnsBadRequestWhenCorrectFlagMissingFromPayload,Answer Returns Bad Request When Correct Flag Missing From Payload.,9
+api/quiz/controller/InterruptControllerTest.java,AnswerTests,answerMapsDerivedExceptions,Answer Maps Derived Exceptions.,9
+api/quiz/controller/InterruptControllerTest.java,AnswerTests,answerReturnsInternalServerErrorForUnexpectedException,Answer Returns Internal Server Error For Unexpected Exception.,9
+api/quiz/controller/InterruptControllerTest.java,AnswerTests,answerAddsCorsHeaderWhenOriginPresent,Answer Adds Cors Header When Origin Present.,6
+api/quiz/controller/InterruptControllerTest.java,SavePreviousScenarioTests,savePreviousScenarioReturnsOkAndForwardsScenario,Save Previous Scenario Returns Ok And Forwards Scenario.,6
+api/quiz/controller/InterruptControllerTest.java,SavePreviousScenarioTests,savePreviousScenarioReturnsBadRequestForMissingBody,Save Previous Scenario Returns Bad Request For Missing Body.,7
+api/quiz/controller/InterruptControllerTest.java,SavePreviousScenarioTests,savePreviousScenarioReturnsBadRequestWhenScenarioMissingFromPayload,Save Previous Scenario Returns Bad Request When Scenario Missing From Payload.,9
+api/quiz/controller/InterruptControllerTest.java,SavePreviousScenarioTests,savePreviousScenarioMapsDerivedExceptions,Save Previous Scenario Maps Derived Exceptions.,9
+api/quiz/controller/InterruptControllerTest.java,SavePreviousScenarioTests,savePreviousScenarioReturnsInternalServerErrorForUnexpectedException,Save Previous Scenario Returns Internal Server Error For Unexpected Exception.,9
+api/quiz/controller/InterruptControllerTest.java,SavePreviousScenarioTests,savePreviousScenarioAddsCorsHeaderWhenOriginPresent,Save Previous Scenario Adds Cors Header When Origin Present.,6
+api/quiz/controller/InterruptControllerTest.java,InterruptContract,interruptRejectsUnsupportedMethod,Interrupt Rejects Unsupported Method.,7
+api/quiz/controller/InterruptControllerTest.java,InterruptContract,interruptRejectsUnsupportedMediaType,Interrupt Rejects Unsupported Media Type.,7
+api/quiz/controller/InterruptControllerTest.java,InterruptContract,interruptMalformedJsonDoesNotCallService,Interrupt Malformed JSON Does Not Call Service.,8
+api/quiz/controller/InterruptControllerTest.java,InterruptContract,interruptPreflightReturnsCorsHeaders,Interrupt Preflight Returns Cors Headers.,6
+api/quiz/controller/InterruptControllerTest.java,ResolveErrorsContract,resolveErrorsRejectsUnsupportedMethod,Resolve Errors Rejects Unsupported Method.,7
+api/quiz/controller/InterruptControllerTest.java,ResolveErrorsContract,resolveErrorsRejectsUnsupportedMediaType,Resolve Errors Rejects Unsupported Media Type.,7
+api/quiz/controller/InterruptControllerTest.java,ResolveErrorsContract,resolveErrorsMalformedJsonDoesNotCallService,Resolve Errors Malformed JSON Does Not Call Service.,8
+api/quiz/controller/InterruptControllerTest.java,AnswerContract,answerRejectsUnsupportedMethod,Answer Rejects Unsupported Method.,7
+api/quiz/controller/InterruptControllerTest.java,AnswerContract,answerRejectsUnsupportedMediaType,Answer Rejects Unsupported Media Type.,7
+api/quiz/controller/InterruptControllerTest.java,AnswerContract,answerMalformedJsonDoesNotCallService,Answer Malformed JSON Does Not Call Service.,8
+api/quiz/controller/InterruptControllerTest.java,AnswerContract,malformedAnswerIdDoesNotCallService,Malformed Answer Id Does Not Call Service.,8
+api/quiz/controller/InterruptControllerTest.java,SaveScenarioContract,saveScenarioRejectsUnsupportedMethod,Save Scenario Rejects Unsupported Method.,7
+api/quiz/controller/InterruptControllerTest.java,SaveScenarioContract,saveScenarioRejectsUnsupportedMediaType,Save Scenario Rejects Unsupported Media Type.,7
+api/quiz/controller/InterruptControllerTest.java,SaveScenarioContract,saveScenarioMalformedJsonDoesNotCallService,Save Scenario Malformed JSON Does Not Call Service.,8
+api/quiz/controller/InterruptControllerTest.java,InterruptBinding,interruptRejectsNumericTeamIdIfEndpointRequiresUuidOrStringShape,Interrupt Rejects Numeric Team Id If Endpoint Requires UUID Or String Shape.,7
+api/quiz/controller/InterruptControllerTest.java,InterruptBinding,interruptAllowsExplicitNullTeamIdAndForwardsIt,Interrupt Allows Explicit Null Team Id And Forwards It.,6
+api/quiz/controller/InterruptControllerTest.java,ResolveBinding,resolveErrorsRejectsWrongJsonTypeForScheduleId,Resolve Errors Rejects Wrong JSON Type For Schedule Id.,7
+api/quiz/controller/InterruptControllerTest.java,ResolveBinding,resolveErrorsAllowsExplicitNullScheduleIdAndForwardsIt,Resolve Errors Allows Explicit Null Schedule Id And Forwards It.,6
+api/quiz/controller/InterruptControllerTest.java,AnswerBinding,answerRejectsStringForBooleanField,Answer Rejects String For Boolean Field.,7
+api/quiz/controller/InterruptControllerTest.java,AnswerBinding,answerRejectsExplicitNullBooleanField,Answer Rejects Explicit Null Boolean Field.,7
+api/quiz/controller/InterruptControllerTest.java,AnswerBinding,answerIgnoresUnknownFieldsWhenMainPayloadIsValid,Answer Ignores Unknown Fields When Main Payload Is Valid.,6
+api/quiz/controller/InterruptControllerTest.java,ScenarioBinding,savePreviousScenarioRejectsStringForNumericField,Save Previous Scenario Rejects String For Numeric Field.,7
+api/quiz/controller/InterruptControllerTest.java,ScenarioBinding,savePreviousScenarioRejectsExplicitNullScenario,Save Previous Scenario Rejects Explicit Null Scenario.,7
+api/quiz/controller/InterruptControllerTest.java,ScenarioBinding,savePreviousScenarioIgnoresUnknownFieldsWhenMainPayloadIsValid,Save Previous Scenario Ignores Unknown Fields When Main Payload Is Valid.,6
+api/quiz/controller/ScheduleControllerTest.java,ReplaySongTests,replaySongReturnsOk,Replay Song Returns Ok.,8
+api/quiz/controller/ScheduleControllerTest.java,ReplaySongTests,replaySongDoesNotValidateRoomCodeFormatAtControllerLevel,Replay Song Does Not Validate Room Code Format At Controller Level.,6
+api/quiz/controller/ScheduleControllerTest.java,ReplaySongTests,replaySongMapsDerivedExceptions,Replay Song Maps Derived Exceptions.,9
+api/quiz/controller/ScheduleControllerTest.java,ReplaySongTests,replaySongReturnsInternalServerErrorForUnexpectedException,Replay Song Returns Internal Server Error For Unexpected Exception.,9
+api/quiz/controller/ScheduleControllerTest.java,ReplaySongTests,replaySongAddsCorsHeaderWhenOriginPresent,Replay Song Adds Cors Header When Origin Present.,6
+api/quiz/controller/ScheduleControllerTest.java,RevealAnswerTests,revealAnswerReturnsOk,Reveal Answer Returns Ok.,8
+api/quiz/controller/ScheduleControllerTest.java,RevealAnswerTests,revealAnswerReturnsBadRequestForMalformedScheduleUuid,Reveal Answer Returns Bad Request For Malformed Schedule UUID.,7
+api/quiz/controller/ScheduleControllerTest.java,RevealAnswerTests,revealAnswerMapsDerivedExceptions,Reveal Answer Maps Derived Exceptions.,9
+api/quiz/controller/ScheduleControllerTest.java,RevealAnswerTests,revealAnswerReturnsInternalServerErrorForUnexpectedException,Reveal Answer Returns Internal Server Error For Unexpected Exception.,9
+api/quiz/controller/ScheduleControllerTest.java,RevealAnswerTests,revealAnswerAddsCorsHeaderWhenOriginPresent,Reveal Answer Adds Cors Header When Origin Present.,6
+api/quiz/controller/ScheduleControllerTest.java,NextTests,nextReturnsOk,Next Returns Ok.,8
+api/quiz/controller/ScheduleControllerTest.java,NextTests,nextDoesNotValidateRoomCodeFormatAtControllerLevel,Next Does Not Validate Room Code Format At Controller Level.,6
+api/quiz/controller/ScheduleControllerTest.java,NextTests,nextMapsDerivedExceptions,Next Maps Derived Exceptions.,9
+api/quiz/controller/ScheduleControllerTest.java,NextTests,nextReturnsInternalServerErrorForUnexpectedException,Next Returns Internal Server Error For Unexpected Exception.,9
+api/quiz/controller/ScheduleControllerTest.java,NextTests,nextAddsCorsHeaderWhenOriginPresent,Next Adds Cors Header When Origin Present.,6
+api/quiz/controller/ScheduleControllerTest.java,ReplayContract,replayRejectsUnsupportedMethod,Replay Rejects Unsupported Method.,7
+api/quiz/controller/ScheduleControllerTest.java,ReplayContract,replayPreflightReturnsCorsHeaders,Replay Preflight Returns Cors Headers.,6
+api/quiz/controller/ScheduleControllerTest.java,ReplayContract,malformedScheduleIdDoesNotCallReplayService,Malformed Schedule Id Does Not Call Replay Service.,8
+api/quiz/controller/ScheduleControllerTest.java,RevealContract,revealRejectsUnsupportedMethod,Reveal Rejects Unsupported Method.,7
+api/quiz/controller/ScheduleControllerTest.java,RevealContract,revealPreflightReturnsCorsHeaders,Reveal Preflight Returns Cors Headers.,6
+api/quiz/controller/ScheduleControllerTest.java,NextContract,nextRejectsUnsupportedMethod,Next Rejects Unsupported Method.,7
+api/quiz/controller/ScheduleControllerTest.java,NextContract,nextReturnsEmptyBodyOnSuccess,Next Returns Empty Body On Success.,8
+api/quiz/controller/ScheduleControllerTest.java,NextContract,nextPreflightReturnsCorsHeaders,Next Preflight Returns Cors Headers.,6
+api/quiz/controller/TeamControllerTest.java,CreateTeamTests,createTeamReturnsSerializedResponse,Create Team Returns Serialized Response.,9
+api/quiz/controller/TeamControllerTest.java,CreateTeamTests,createTeamReturnsBadRequestForMissingBody,Create Team Returns Bad Request For Missing Body.,7
+api/quiz/controller/TeamControllerTest.java,CreateTeamTests,createTeamForwardsNullFieldsWhenPayloadOmitsParameters,Create Team Forwards Null Fields When Payload Omits Parameters.,6
+api/quiz/controller/TeamControllerTest.java,CreateTeamTests,createTeamDoesNotValidateRoomCodeFormatAtControllerLevel,Create Team Does Not Validate Room Code Format At Controller Level.,6
+api/quiz/controller/TeamControllerTest.java,CreateTeamTests,createTeamMapsDerivedExceptions,Create Team Maps Derived Exceptions.,9
+api/quiz/controller/TeamControllerTest.java,CreateTeamTests,createTeamReturnsInternalServerErrorForUnexpectedException,Create Team Returns Internal Server Error For Unexpected Exception.,9
+api/quiz/controller/TeamControllerTest.java,CreateTeamTests,createTeamAddsCorsHeaderWhenOriginPresent,Create Team Adds Cors Header When Origin Present.,6
+api/quiz/controller/TeamControllerTest.java,KickTeamTests,kickTeamReturnsOkAndForwardsIds,Kick Team Returns Ok And Forwards Ids.,6
+api/quiz/controller/TeamControllerTest.java,KickTeamTests,kickTeamDoesNotValidateTeamIdFormatAtControllerLevel,Kick Team Does Not Validate Team Id Format At Controller Level.,6
+api/quiz/controller/TeamControllerTest.java,KickTeamTests,kickTeamDoesNotValidateRoomCodeFormatAtControllerLevel,Kick Team Does Not Validate Room Code Format At Controller Level.,6
+api/quiz/controller/TeamControllerTest.java,KickTeamTests,kickTeamMapsDerivedExceptions,Kick Team Maps Derived Exceptions.,9
+api/quiz/controller/TeamControllerTest.java,KickTeamTests,kickTeamReturnsInternalServerErrorForUnexpectedException,Kick Team Returns Internal Server Error For Unexpected Exception.,9
+api/quiz/controller/TeamControllerTest.java,KickTeamTests,kickTeamAddsCorsHeaderWhenOriginPresent,Kick Team Adds Cors Header When Origin Present.,6
+api/quiz/controller/TeamControllerTest.java,CreateTeamContract,createTeamRejectsUnsupportedMethod,Create Team Rejects Unsupported Method.,7
+api/quiz/controller/TeamControllerTest.java,CreateTeamContract,createTeamRejectsUnsupportedMediaType,Create Team Rejects Unsupported Media Type.,7
+api/quiz/controller/TeamControllerTest.java,CreateTeamContract,createTeamPreflightReturnsCorsHeaders,Create Team Preflight Returns Cors Headers.,6
+api/quiz/controller/TeamControllerTest.java,CreateTeamContract,createTeamMalformedJsonDoesNotCallService,Create Team Malformed JSON Does Not Call Service.,8
+api/quiz/controller/TeamControllerTest.java,KickTeamContract,kickTeamRejectsUnsupportedMethod,Kick Team Rejects Unsupported Method.,7
+api/quiz/controller/TeamControllerTest.java,KickTeamContract,kickTeamReturnsEmptyBodyOnSuccess,Kick Team Returns Empty Body On Success.,8
+api/quiz/controller/TeamControllerTest.java,KickTeamContract,kickTeamPreflightReturnsCorsHeaders,Kick Team Preflight Returns Cors Headers.,6
+api/quiz/controller/TeamControllerTest.java,CreateTeamBinding,createTeamCoercesNumericNameToStringAndForwardsIt,Create Team Coerces Numeric Name To String And Forwards It.,6
+api/quiz/controller/TeamControllerTest.java,CreateTeamBinding,createTeamAllowsNullNameAndForwardsItToService,Create Team Allows Null Name And Forwards It To Service.,6
+api/quiz/controller/TeamControllerTest.java,CreateTeamBinding,createTeamUnknownFieldsAreIgnoredWhenMainPayloadIsValid,Create Team Unknown Fields Are Ignored When Main Payload Is Valid.,8
+api/assets/controller/AudioAssetControllerTest.java,,playSnippetReturnsAudioBytesAndRangeHeader,Play Snippet Returns Audio Bytes And Range Header.,8
+api/assets/controller/AudioAssetControllerTest.java,,playSnippetMapsDerivedExceptionStatusAndBody,Play Snippet Maps Derived Exception Status And Body.,9
+api/assets/controller/AudioAssetControllerTest.java,,playSnippetReturnsInternalServerErrorForUnexpectedException,Play Snippet Returns Internal Server Error For Unexpected Exception.,9
+api/assets/controller/AudioAssetControllerTest.java,,playSnippetAddsCorsHeaderWhenOriginPresent,Play Snippet Adds Cors Header When Origin Present.,6
+api/assets/controller/AudioAssetControllerTest.java,,playAnswerReturnsAudioBytesAndRangeHeader,Play Answer Returns Audio Bytes And Range Header.,8
+api/assets/controller/AudioAssetControllerTest.java,,playAnswerMapsDerivedExceptionStatusAndBody,Play Answer Maps Derived Exception Status And Body.,9
+api/assets/controller/AudioAssetControllerTest.java,,playAnswerReturnsInternalServerErrorForUnexpectedException,Play Answer Returns Internal Server Error For Unexpected Exception.,9
+api/assets/controller/AudioAssetControllerTest.java,,playAnswerAddsCorsHeaderWhenOriginPresent,Play Answer Adds Cors Header When Origin Present.,6
+api/assets/controller/AudioAssetControllerTest.java,,snippetRejectsUnsupportedHttpMethod,Snippet Rejects Unsupported Http Method.,7
+api/assets/controller/AudioAssetControllerTest.java,,answerRejectsUnsupportedHttpMethod,Answer Rejects Unsupported Http Method.,7
+api/assets/controller/AudioAssetControllerTest.java,,snippetOptionsPreflightIncludesCorsHeaders,Snippet Options Preflight Includes Cors Headers.,6
+api/assets/controller/AudioAssetControllerTest.java,,answerOptionsPreflightIncludesCorsHeaders,Answer Options Preflight Includes Cors Headers.,6
+api/assets/controller/AudioAssetControllerTest.java,,snippetResponseDoesNotPretendToBeJson,Snippet Response Does Not Pretend To Be JSON.,8
+api/assets/controller/AudioAssetControllerTest.java,,malformedSnippetUuidDoesNotCallService,Malformed Snippet UUID Does Not Call Service.,8
+api/assets/controller/AudioAssetControllerTest.java,,malformedAnswerUuidDoesNotCallService,Malformed Answer UUID Does Not Call Service.,8

--- a/docs/developer-guide/testing/test-catalog.md
+++ b/docs/developer-guide/testing/test-catalog.md
@@ -83,11 +83,31 @@ When adding, merging, or deleting tests:
 - keep descriptions short and behavior-focused
 - note the test suite/group where the test belongs
 
+## Controller tests
+
+Controller tests exist for the REST API layer and are organized one file per controller.
+
+These tests typically verify:
+
+- HTTP status codes
+- response body content
+- response media types
+- malformed payload handling
+- request rejection before service invocation
+- controller-managed exception responses
+
+Controller endpoints are expected to have tests covering:
+
+- happy path behavior
+- `DerivedException` behavior
+- unexpected exception behavior
+
+For JSON endpoints, tests should verify `application/json` media type for both success and controller-handled error responses.
+
 ## Future expansion
 
 This catalog should later expand to include:
 
-- controller tests
 - repository integration tests
 - frontend unit and integration tests
 - end-to-end regression tests

--- a/docs/developer-guide/testing/testing-overview.md
+++ b/docs/developer-guide/testing/testing-overview.md
@@ -16,24 +16,28 @@ The goal of the test suite is not just to prove that code works on the happy pat
 
 ## Current Test Focus
 
-The backend test suite currently focuses primarily on the service layer, with strongest coverage around the most rule-heavy services:
+The backend test suite also includes targeted verification of
+WebSocket-related behavior where it intersects with core game logic.
 
-- `GameServiceImpl`
-- `InterruptServiceImpl`
-- `ScheduleServiceImpl`
-- `CategoryServiceImpl`
-- `TeamServiceImpl`
-- `SongServiceImpl`
+Rather than testing WebSocket infrastructure directly, tests focus on
+validating that services correctly trigger broadcast side effects
+through the messaging gateway when state changes occur.
 
 Particular emphasis has been placed on:
 
-- game stage transitions
-- interrupt rules and resolution
-- schedule progression and edge cases
-- category selection rules
-- state recovery behavior
-- websocket broadcast side effects
-- `contextFetch`, which acts as the core state projection method for the application
+-   verifying that broadcasts occur when stage transitions happen
+-   ensuring interrupt and answer resolution triggers appropriate state
+    updates
+-   confirming that broadcast payloads contain correct context
+    information
+-   validating that broadcasts are suppressed when operations are
+    rejected or invalid
+-   ensuring correct ordering of persistence and broadcast side effects
+    when required
+
+These tests ensure that the real-time synchronization layer between
+Admin and TV clients remains consistent with backend state transitions
+without requiring a full WebSocket environment during unit testing.
 
 ## Why `contextFetch` matters
 
@@ -55,13 +59,24 @@ If this method becomes incorrect, the application can appear broken to clients e
 
 ### Current layers
 
-The project currently has strong backend unit/service coverage and smaller supporting test coverage for lower-level helpers.
+The project currently has strong backend service-layer unit tests and controller tests that validate the HTTP contract of REST endpoints.
+
+Controller tests verify:
+- happy path responses
+- `DerivedException` responses
+- unexpected error responses
+- response status codes
+- response body content when applicable
+- response media types
+- rejection of malformed requests before reaching service logic
+
+Controller-managed error responses are centralized through
+`com.cevapinxile.cestereg.api.support.ApiErrorResponses.handleApiException`, and this behavior is considered part of the API contract.
 
 ### Planned layers
 
 The following layers should be expanded after the service layer is considered stable:
 
-- controller tests
 - repository integration tests
 - frontend unit tests
 - frontend integration tests

--- a/docs/developer-guide/testing/writing-tests.md
+++ b/docs/developer-guide/testing/writing-tests.md
@@ -145,3 +145,37 @@ Typical expectations:
 - `testing-overview.md` explains the overall strategy and purpose
 - `test-catalog.md` describes what is already covered
 - `test-catalog.csv` provides a more detailed inventory of individual tests
+
+
+## Writing controller tests
+
+Controller tests protect the HTTP contract of REST endpoints.
+
+For every endpoint, tests should normally cover:
+
+- happy path behavior
+- `DerivedException` behavior
+- unexpected exception behavior
+
+Each of these paths should verify:
+
+- HTTP status code
+- response content when applicable
+- response `Content-Type` when applicable
+
+When an endpoint returns JSON, tests should assert the `application/json`
+media type for success and controller-handled error responses.
+
+For endpoints returning binary media (for example audio snippets),
+tests should verify the success media type and ensure controller-handled
+error responses return JSON.
+
+Controller-level exception handling is centralized in
+
+`com.cevapinxile.cestereg.api.support.ApiErrorResponses.handleApiException`
+
+Tests should treat this response format as part of the API contract.
+
+Controller tests should also validate malformed request handling and confirm
+that service-layer methods are not called when the request is rejected at
+the controller boundary.


### PR DESCRIPTION
## Linked Issue
Closes #64

## What changed
- Added controller tests covering success, domain exception, and unexpected failure scenarios
- Added validation for HTTP status, content, and media types
- Consolidated tests into controller-specific files
- Removed overlapping tests
- Standardized Mockito usage via static imports

## Why
Controller tests define the HTTP contract of the API. Increasing coverage ensures consistent responses and protects against regressions.

## DB changes
- [x] None
- [ ] Migration included

## API changes
- [x] None
- [ ] OpenAPI updated
- [ ] Error catalog updated

## Tests
- [x] Added/updated backend tests
- [ ] Added/updated frontend tests
- [ ] Added/updated E2E tests

## Security / data minimization
- [x] TV receives no answers
- [x] No secrets logged